### PR TITLE
feat: Support jpg, jpeg, and png image formats

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,23 +8,22 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"bytes" // Added for PNG encoding buffer
 	"image" // Added for image manipulation
-	"image/draw" // Added for drawing images
-	"image/png" // Added for PNG encoding
+	_ "image/jpeg" // Added for JPEG decoding (register decoder)
+	_ "image/png" // Added for PNG encoding (register decoder)
 
 	"github.com/signintech/gopdf"
-	"golang.org/x/image/webp"
+	_ "golang.org/x/image/webp" // Added for WebP decoding (register decoder)
 )
 
 func main() {
 	// Define command-line flags for input and output paths
-	inputDir := flag.String("i", ".", "Input directory containing .webp files")
+	inputDir := flag.String("i", ".", "Input directory containing image files (.webp, .jpg, .jpeg, .png)")
 	outputFile := flag.String("o", "output.pdf", "Output PDF file name")
 	flag.Parse()
 
 	// Call the main conversion function
-	err := convertWebPToPDF(*inputDir, *outputFile)
+	err := convertImagesToPDF(*inputDir, *outputFile)
 	if err != nil {
 		log.Fatalf("❌ Failed to convert images to PDF: %v", err)
 	}
@@ -32,29 +31,35 @@ func main() {
 	fmt.Printf("✅ Successfully created '%s' from images in '%s'\n", *outputFile, *inputDir)
 }
 
-// convertWebPToPDF finds all .webp files, decodes them, and adds them to a PDF.
-func convertWebPToPDF(inputDir, outputFile string) error {
+// convertImagesToPDF finds all supported image files, decodes them, and adds them to a PDF.
+func convertImagesToPDF(inputDir, outputFile string) error {
 	// 1. Read all files from the input directory
 	files, err := os.ReadDir(inputDir)
 	if err != nil {
 		return fmt.Errorf("could not read directory %s: %w", inputDir, err)
 	}
 
-	// 2. Filter for .webp files and store their names
-	var webpFiles []string
+	// 2. Filter for supported image files and store their names
+	var imageFiles []string
+	supportedExtensions := map[string]bool{
+		".webp": true,
+		".jpg":  true,
+		".jpeg": true,
+		".png":  true,
+	}
 	for _, file := range files {
-		if !file.IsDir() && strings.HasSuffix(strings.ToLower(file.Name()), ".webp") {
-			webpFiles = append(webpFiles, file.Name())
+		if !file.IsDir() && supportedExtensions[strings.ToLower(filepath.Ext(file.Name()))] {
+			imageFiles = append(imageFiles, file.Name())
 		}
 	}
 
-	if len(webpFiles) == 0 {
-		return fmt.Errorf("no .webp files found in directory %s", inputDir)
+	if len(imageFiles) == 0 {
+		return fmt.Errorf("no supported image files (.webp, .jpg, .jpeg, .png) found in directory %s", inputDir)
 	}
 
 	// 3. Sort the files alphabetically
-	sort.Strings(webpFiles)
-	fmt.Printf("Found %d .webp files to convert.\n", len(webpFiles))
+	sort.Strings(imageFiles)
+	fmt.Printf("Found %d image files to convert.\n", len(imageFiles))
 
 	// 4. Initialize a new PDF document using gopdf
 	pdf := gopdf.GoPdf{}
@@ -76,7 +81,7 @@ func convertWebPToPDF(inputDir, outputFile string) error {
 	maxConcurrentDecoders := 4
 
 	// Create a channel to send processed image data.
-	// The buffer size is len(webpFiles) to prevent blocking if PDF processing is slow,
+	// The buffer size is len(imageFiles) to prevent blocking if PDF processing is slow,
 	// though with a semaphore, this might not be strictly necessary if workers block on semaphore.
 	// Let's make it unbuffered and rely on the semaphore for backpressure.
 	processedImageChan := make(chan ProcessedImage)
@@ -84,7 +89,7 @@ func convertWebPToPDF(inputDir, outputFile string) error {
 	semaphoreChan := make(chan struct{}, maxConcurrentDecoders)
 
 	// Launch goroutines to decode images.
-	for i, filename := range webpFiles {
+	for i, filename := range imageFiles {
 		go func(idx int, fname string) {
 			semaphoreChan <- struct{}{} // Acquire a slot
 			defer func() { <-semaphoreChan }() // Release the slot
@@ -99,9 +104,11 @@ func convertWebPToPDF(inputDir, outputFile string) error {
 			}
 			defer file.Close()
 
-			decodedImg, err := webp.Decode(file)
+			// Use image.Decode which automatically detects the format.
+			// Ensure necessary image format packages (image/jpeg, image/png, golang.org/x/image/webp) are imported for decoder registration.
+			decodedImg, _, err := image.Decode(file) // The second return value is format string, ignored here.
 			if err != nil {
-				processedImageChan <- ProcessedImage{Index: idx, Filename: fname, Error: fmt.Errorf("could not decode WebP: %w", err)}
+				processedImageChan <- ProcessedImage{Index: idx, Filename: fname, Error: fmt.Errorf("could not decode image: %w", err)}
 				return
 			}
 
@@ -111,8 +118,8 @@ func convertWebPToPDF(inputDir, outputFile string) error {
 
 	// Collect results and add to PDF.
 	// We need to store them temporarily to ensure correct order if they arrive out of order.
-	results := make([]ProcessedImage, len(webpFiles))
-	for i := 0; i < len(webpFiles); i++ {
+	results := make([]ProcessedImage, len(imageFiles))
+	for i := 0; i < len(imageFiles); i++ {
 		res := <-processedImageChan
 		results[res.Index] = res // Store in the correct order using the original index
 	}


### PR DESCRIPTION
The script now processes .jpg, .jpeg, and .png files in addition to .webp files.

This involved:
- Updating file filtering logic to include the new types.
- Changing from `webp.Decode` to `image.Decode` for automatic format detection.
- Ensuring necessary decoder packages (jpeg, png, webp) are imported for their side effects (decoder registration).
- Renaming `convertWebPToPDF` to `convertImagesToPDF` to reflect its broader capability.
- Updating related messages and comments.