### PR TITLE
Feat: Convert CLI tool to API service for image to PDF conversion

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1,0 +1,312 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync" // For order preservation with fetched URLs
+
+	"manga_to_pdf/internal/converter"
+)
+
+const defaultMaxMemory = 32 << 20 // 32 MB for multipart form parsing
+
+type APIErrorResponse struct {
+	Error   string      `json:"error"`
+	Details interface{} `json:"details,omitempty"`
+}
+
+func writeJSONError(w http.ResponseWriter, message string, details interface{}, statusCode int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	errResponse := APIErrorResponse{
+		Error:   message,
+		Details: details,
+	}
+	if err := json.NewEncoder(w).Encode(errResponse); err != nil {
+		slog.Error("Failed to write JSON error response", "error", err)
+		// Fallback if JSON encoding fails
+		http.Error(w, `{"error":"Failed to serialize error message"}`, http.StatusInternalServerError)
+	}
+}
+
+// Helper struct to manage indexed image sources, especially when fetching URLs concurrently
+type indexedImageSource struct {
+	source converter.ImageSource
+	err    error
+}
+
+func HandleConvert(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, "Invalid request method", "Only POST is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Ensure body is closed
+	defer func() {
+		if r.Body != nil {
+			io.Copy(io.Discard, r.Body) // Drain any remaining parts of the body
+			r.Body.Close()
+		}
+	}()
+
+	// Parse multipart form
+	// The request body is an io.ReadCloser. It can be read once.
+	// ParseMultipartForm reads the body.
+	if err := r.ParseMultipartForm(defaultMaxMemory); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF { // These can happen if body is empty or malformed
+			slog.Warn("Empty or malformed request body", "error", err)
+			writeJSONError(w, "Malformed request body or empty request", err.Error(), http.StatusBadRequest)
+			return
+		}
+		slog.Error("Failed to parse multipart form", "error", err)
+		writeJSONError(w, "Failed to parse request data", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	slog.Debug("Multipart form parsed successfully")
+
+	// --- Configuration ---
+	apiConfig := converter.NewDefaultConfig()
+	configStr := r.FormValue("config")
+	if configStr != "" {
+		slog.Debug("Received config string", "config", configStr)
+		if err := json.Unmarshal([]byte(configStr), apiConfig); err != nil {
+			slog.Warn("Failed to parse 'config' JSON", "error", err, "configStr", configStr)
+			writeJSONError(w, "Invalid 'config' JSON", err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Validate config values (JPEGQuality, NumWorkers)
+		if apiConfig.JPEGQuality < 1 || apiConfig.JPEGQuality > 100 {
+			slog.Warn("Invalid JPEG quality in config, using default", "provided", apiConfig.JPEGQuality)
+			apiConfig.JPEGQuality = converter.NewDefaultConfig().JPEGQuality // Reset to default
+		}
+		if apiConfig.NumWorkers <= 0 {
+			slog.Warn("Invalid NumWorkers in config, using default", "provided", apiConfig.NumWorkers)
+			apiConfig.NumWorkers = converter.NewDefaultConfig().NumWorkers // Reset to default
+		}
+		slog.Debug("Successfully parsed config", "parsedConfig", apiConfig)
+	} else {
+		slog.Debug("No 'config' provided, using default config")
+	}
+
+
+	var imageSources []converter.ImageSource
+	var sourceIndex int // To maintain original order
+
+	// --- Process Uploaded Files ---
+	// r.MultipartForm is populated by ParseMultipartForm.
+	uploadedFiles := r.MultipartForm.File["images"]
+	slog.Debug("Processing uploaded files", "count", len(uploadedFiles))
+	for _, fileHeader := range uploadedFiles {
+		slog.Debug("Processing uploaded file", "filename", fileHeader.Filename, "size", fileHeader.Size)
+		file, err := fileHeader.Open()
+		if err != nil {
+			slog.Error("Failed to open uploaded file", "filename", fileHeader.Filename, "error", err)
+			// Consider if one bad file should stop the whole process or just be skipped.
+			// For now, let's try to continue with other files, but this one will be skipped.
+			// To properly skip, we'd need to collect errors and report them.
+			// For simplicity in this step, a single file error might cause a general failure.
+			// A more robust approach would be to collect all sources and errors, then decide.
+			writeJSONError(w, fmt.Sprintf("Failed to open uploaded file: %s", fileHeader.Filename), err.Error(), http.StatusInternalServerError)
+			return // Early exit for now
+		}
+		// Note: The 'file' (multipart.File) needs to be closed. converter.processSingleImage will close it.
+
+		contentType := fileHeader.Header.Get("Content-Type")
+		if contentType == "" || contentType == "application/octet-stream" {
+			// Fallback to extension if content type is generic or missing
+			contentType = converter.GetContentTypeFromFilename(fileHeader.Filename)
+			slog.Debug("Guessed content type from filename", "filename", fileHeader.Filename, "guessedType", contentType)
+		}
+
+		imageSources = append(imageSources, converter.ImageSource{
+			OriginalFilename: fileHeader.Filename,
+			Reader:           file, // This is an io.ReadCloser
+			ContentType:      contentType,
+			Index:            sourceIndex,
+		})
+		sourceIndex++
+	}
+	slog.Debug("Finished processing uploaded files", "count", len(imageSources))
+
+	// --- Process Image URLs ---
+	imageURLsStr := r.FormValue("image_urls")
+	var fetchedSources []converter.ImageSource // To hold successfully fetched sources from URLs
+
+	if imageURLsStr != "" {
+		slog.Debug("Processing image_urls", "urls_string", imageURLsStr)
+		var urls []string
+		if err := json.Unmarshal([]byte(imageURLsStr), &urls); err != nil {
+			slog.Warn("Failed to parse 'image_urls' JSON", "error", err, "urlsStr", imageURLsStr)
+			// Close any already opened uploaded files before returning
+			for _, src := range imageSources {
+				if src.Reader != nil {
+					src.Reader.Close()
+				}
+			}
+			writeJSONError(w, "Invalid 'image_urls' JSON", err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if len(urls) > 0 {
+			slog.Debug("Fetching images from URLs", "count", len(urls))
+			fetchedChan := make(chan indexedImageSource, len(urls))
+			var wg sync.WaitGroup
+
+			for _, urlStr := range urls {
+				wg.Add(1)
+				go func(u string, currentIndex int) {
+					defer wg.Done()
+					select {
+					case <-ctx.Done():
+						fetchedChan <- indexedImageSource{err: ctx.Err()}
+						return
+					default:
+						slog.Debug("Fetching URL", "url", u, "index", currentIndex)
+						imgSrc, err := converter.FetchImage(ctx, u, currentIndex) // Pass current global index
+						if err != nil {
+							slog.Warn("Failed to fetch image from URL", "url", u, "error", err)
+							// Send error to channel, reader is already closed by FetchImage on error
+							fetchedChan <- indexedImageSource{err: err, source: converter.ImageSource{OriginalFilename: u, Index: currentIndex}}
+						} else {
+							slog.Debug("Successfully fetched URL", "url", u, "filename", imgSrc.OriginalFilename)
+							fetchedChan <- indexedImageSource{source: imgSrc}
+						}
+					}
+				}(urlStr, sourceIndex) // Pass the current sourceIndex for this URL
+				sourceIndex++ // Increment global index for each URL source
+			}
+
+			wg.Wait()
+			close(fetchedChan)
+
+			tempFetchedSources := make([]indexedImageSource, 0, len(urls))
+			for res := range fetchedChan {
+				tempFetchedSources = append(tempFetchedSources, res)
+			}
+			// Sort by original index to maintain order relative to other URLs
+			sort.Slice(tempFetchedSources, func(i, j int) bool {
+				return tempFetchedSources[i].source.Index < tempFetchedSources[j].source.Index
+			})
+
+			urlErrors := []string{}
+			for _, res := range tempFetchedSources {
+				if res.err != nil {
+					// Collect errors for URLs. Decide if one failure means total failure.
+					// For now, collect and log. If an error occurs, the source.Reader will be nil or closed.
+					urlErrors = append(urlErrors, fmt.Sprintf("Failed to fetch %s: %s", res.source.OriginalFilename, res.err.Error()))
+					// Ensure reader is closed if somehow it wasn't (FetchImage should handle this)
+					if res.source.Reader != nil {
+						res.source.Reader.Close()
+					}
+				} else if res.source.Reader != nil { // Only add if successfully fetched and reader is present
+					fetchedSources = append(fetchedSources, res.source)
+				}
+			}
+
+			if len(urlErrors) > 0 && len(fetchedSources) == 0 && len(uploadedFiles) == 0 {
+				// All URL fetches failed, and no uploaded files either
+				slog.Warn("All image URL fetches failed and no uploaded files.", "errors", strings.Join(urlErrors, "; "))
+				// Close any uploaded file readers if they existed but fetchedSources is the only source type
+				for _, src := range imageSources { // imageSources here only contains uploaded files
+					if src.Reader != nil {
+						src.Reader.Close()
+					}
+				}
+				writeJSONError(w, "Failed to fetch any images from URLs and no files uploaded.", urlErrors, http.StatusUnprocessableEntity)
+				return
+			}
+			// Log URL errors if any, but proceed if some images were fetched or uploaded
+			if len(urlErrors) > 0 {
+				slog.Warn("Some image URL fetches failed", "errors", strings.Join(urlErrors, "; "))
+			}
+		}
+	}
+	// Append successfully fetched URL sources to the main list
+	imageSources = append(imageSources, fetchedSources...)
+	slog.Debug("Finished processing image_urls", "successfully_fetched_count", len(fetchedSources))
+
+
+	// --- Final Check and Cleanup ---
+	if len(imageSources) == 0 {
+		slog.Info("No image files or URLs provided or successfully processed up to this point.")
+		writeJSONError(w, "No images provided", "Please upload files or provide image URLs.", http.StatusBadRequest)
+		return
+	}
+
+	// Ensure sources are sorted by their original index before passing to converter
+	sort.SliceStable(imageSources, func(i, j int) bool {
+		return imageSources[i].Index < imageSources[j].Index
+	})
+
+	// Log the final list of sources being sent to the converter
+	for idx, src := range imageSources {
+		slog.Debug("Source for conversion", "final_list_index", idx, "original_index", src.Index, "filename", src.OriginalFilename, "has_reader", src.Reader != nil, "url", src.URL)
+	}
+
+
+	// --- Conversion ---
+	var pdfOutputBuffer bytes.Buffer
+	slog.Info("Starting PDF conversion with converter package", "num_sources", len(imageSources), "config", apiConfig)
+
+	// The readers in imageSources (from uploads or FetchImage) will be closed by the converter package.
+	hasContent, err := converter.ConvertToPDF(ctx, imageSources, apiConfig, &pdfOutputBuffer)
+	if err != nil {
+		slog.Error("PDF conversion failed", "error", err)
+		// imageSources readers should have been closed by ConvertToPDF or its sub-functions
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			writeJSONError(w, "PDF conversion timed out or was canceled by client", err.Error(), http.StatusGatewayTimeout) // Or 499 Client Closed Request if detectable
+		} else if errors.Is(err, converter.ErrNoSupportedImages) {
+			writeJSONError(w, "No images could be processed into the PDF", err.Error(), http.StatusUnprocessableEntity)
+		} else if errors.Is(err, converter.ErrUnsupportedContentType) {
+			writeJSONError(w, "Unsupported image content type from URL", err.Error(), http.StatusUnprocessableEntity)
+		} else {
+			writeJSONError(w, "Failed to convert images to PDF", err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if !hasContent {
+		slog.Info("Conversion successful but PDF has no content (e.g., all images were invalid or skipped).")
+		writeJSONError(w, "No content added to PDF", "All provided images might have been invalid, corrupted, or unsupported.", http.StatusUnprocessableEntity)
+		return
+	}
+
+	// --- Success Response ---
+	outputFilename := apiConfig.OutputFilename
+	if outputFilename == "" {
+		outputFilename = "converted.pdf"
+	}
+	// Sanitize filename slightly (very basic)
+	outputFilename = strings.ReplaceAll(outputFilename, "/", "_")
+	outputFilename = strings.ReplaceAll(outputFilename, "\"", "")
+	if !strings.HasSuffix(strings.ToLower(outputFilename), ".pdf") {
+		outputFilename += ".pdf"
+	}
+
+
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, outputFilename))
+	contentLength := pdfOutputBuffer.Len()
+	w.Header().Set("Content-Length", strconv.Itoa(contentLength))
+
+	slog.Info("Successfully generated PDF", "filename", outputFilename, "size", contentLength)
+	if _, err := pdfOutputBuffer.WriteTo(w); err != nil {
+		// This error usually means the client closed the connection.
+		slog.Error("Failed to write PDF to response", "error", err)
+		// Cannot send JSON error here as headers are already sent.
+	}
+}
+
+[end of api/handlers.go]

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -1,0 +1,436 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"manga_to_pdf/internal/converter" // Assuming this path is correct
+)
+
+// Helper function to create a new multipart/form-data request with files and form values.
+func newFileUploadRequest(t *testing.T, url string, params map[string]string, files map[string]string) *http.Request {
+	t.Helper()
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+
+	for key, val := range params {
+		err := writer.WriteField(key, val)
+		if err != nil {
+			t.Fatalf("Failed to write field %s: %v", key, err)
+		}
+	}
+
+	for key, path := range files {
+		// Use a real small image if available, otherwise a dummy text file from testdata
+		fullPath := filepath.Join("testdata", path)
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			// Create a dummy file if it doesn't exist, for basic testing
+			// This is essential if actual image files are not checked into the repo for tests.
+			dummyPath := filepath.Join("testdata", "dummy_api_test_file.txt")
+			_ = os.WriteFile(dummyPath, []byte("dummy content for "+path), 0644)
+			fullPath = dummyPath
+			slog.Warn("API Test: image file not found, using dummy", "path", path, "using", fullPath)
+		}
+
+
+		file, err := os.Open(fullPath)
+		if err != nil {
+			t.Fatalf("Failed to open file %s: %v", fullPath, err)
+		}
+		defer file.Close()
+
+		part, err := writer.CreateFormFile(key, filepath.Base(path))
+		if err != nil {
+			t.Fatalf("Failed to create form file for %s: %v", path, err)
+		}
+		_, err = io.Copy(part, file)
+		if err != nil {
+			t.Fatalf("Failed to copy file content for %s: %v", path, err)
+		}
+	}
+
+	err := writer.Close()
+	if err != nil {
+		t.Fatalf("Failed to close multipart writer: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+// TestHandleConvert_NoImages tests the scenario where no images are provided.
+func TestHandleConvert_NoImages(t *testing.T) {
+	req := newFileUploadRequest(t, "/convert", map[string]string{}, map[string]string{})
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+		t.Logf("Response body: %s", rr.Body.String())
+	}
+
+	var resp APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Could not parse JSON response: %v", err)
+	}
+	expectedError := "No images provided"
+	if !strings.Contains(resp.Error, expectedError) {
+		t.Errorf("handler returned unexpected error message: got '%s' want substring '%s'", resp.Error, expectedError)
+	}
+}
+
+// TestHandleConvert_InvalidConfigJSON tests providing malformed JSON in the 'config' field.
+func TestHandleConvert_InvalidConfigJSON(t *testing.T) {
+	params := map[string]string{
+		"config": "{'output_filename': 'test.pdf', \"jpeg_quality\": invalid}", // Invalid JSON
+	}
+	// Need at least one image file for the handler to proceed to config parsing for this specific test path
+	// otherwise it might fail earlier due to "no images".
+	files := map[string]string{
+		"images": "dummy.txt", // dummy.txt should be in api/testdata
+	}
+	req := newFileUploadRequest(t, "/convert", params, files)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+		t.Logf("Response body: %s", rr.Body.String())
+		return // Avoid further checks if status is wrong
+	}
+
+	var resp APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Could not parse JSON response: %v. Body: %s", err, rr.Body.String())
+	}
+	expectedError := "Invalid 'config' JSON"
+	if !strings.Contains(resp.Error, expectedError) {
+		t.Errorf("handler returned unexpected error message: got '%s' want substring '%s'", resp.Error, expectedError)
+	}
+}
+
+// TestHandleConvert_InvalidImageURLsJSON tests providing malformed JSON in 'image_urls'.
+func TestHandleConvert_InvalidImageURLsJSON(t *testing.T) {
+	params := map[string]string{
+		"image_urls": "['http://example.com/image.jpg', invalid_url]", // Invalid JSON array
+	}
+	req := newFileUploadRequest(t, "/convert", params, map[string]string{}) // No files, just URL
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+		t.Logf("Response body: %s", rr.Body.String())
+		return
+	}
+	var resp APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Could not parse JSON response: %v. Body: %s", err, rr.Body.String())
+	}
+	expectedError := "Invalid 'image_urls' JSON"
+	if !strings.Contains(resp.Error, expectedError) {
+		t.Errorf("handler returned unexpected error message: got '%s' want substring '%s'", resp.Error, expectedError)
+	}
+}
+
+
+// TestHandleConvert_FetchImageFailures tests when URL fetching fails.
+func TestHandleConvert_FetchImageFailures(t *testing.T) {
+	// Setup a local server that will return errors for image URLs
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "notfound.jpg") {
+			w.WriteHeader(http.StatusNotFound)
+		} else if strings.HasSuffix(r.URL.Path, "badtype.jpg") {
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, "this is not an image")
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer mockServer.Close()
+
+	urlsJSON := fmt.Sprintf(`["%s/notfound.jpg", "%s/badtype.jpg"]`, mockServer.URL, mockServer.URL)
+	params := map[string]string{
+		"image_urls": urlsJSON,
+	}
+	req := newFileUploadRequest(t, "/convert", params, map[string]string{})
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+	handler.ServeHTTP(rr, req)
+
+	// Expect 422 because some images might be processed (if any were uploaded),
+	// but fetching these URLs will fail. If only URLs are provided and all fail, it's 422.
+	if status := rr.Code; status != http.StatusUnprocessableEntity {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusUnprocessableEntity)
+		t.Logf("Response body: %s", rr.Body.String())
+		return
+	}
+	var resp APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Could not parse JSON response: %v", err)
+	}
+	// The error message might vary, but it should indicate failure to fetch or process.
+	// Example: "Failed to fetch any images from URLs and no files uploaded."
+	// or "No images could be processed into the PDF" if converter.ErrNoSupportedImages is hit.
+	if resp.Error == "" {
+		t.Error("Expected an error message, got empty")
+	} else {
+		t.Logf("Received error for fetch failures: %s, Details: %v", resp.Error, resp.Details)
+	}
+	// Check that details might contain info about the failed URLs
+	if resp.Details == nil {
+		t.Logf("Error details are nil, which is acceptable if the main error is descriptive.")
+	} else {
+		detailsStr, ok := resp.Details.(string) // Or []string depending on how HandleConvert formats it
+		if ok {
+			if !strings.Contains(detailsStr, "notfound.jpg") && !strings.Contains(detailsStr, "badtype.jpg") {
+				// This check is too specific if the details format changes.
+				// More generally, just log the details.
+				t.Logf("Details string does not explicitly mention failed URLs, but this might be ok. Details: %s", detailsStr)
+			}
+		} else {
+			t.Logf("Details are not a simple string: %T %v", resp.Details, resp.Details)
+		}
+
+	}
+}
+
+// TestHandleConvert_SuccessfulConversion_DummyFileAsImage
+// This test uses a dummy text file. The converter.ConvertToPDF will fail to process it as an image.
+// So, the API should return an error (e.g., 422 Unprocessable Entity).
+func TestHandleConvert_DummyFileAsImage(t *testing.T) {
+	// Ensure dummy.txt is in api/testdata
+	files := map[string]string{
+		"images": "dummy.txt",
+	}
+	params := map[string]string{
+		"config": `{"output_filename": "test_dummy.pdf"}`,
+	}
+	req := newFileUploadRequest(t, "/convert", params, files)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusUnprocessableEntity {
+		t.Errorf("handler returned wrong status code with dummy file: got %v want %v", status, http.StatusUnprocessableEntity)
+		t.Logf("Response body: %s", rr.Body.String())
+		return
+	}
+
+	var resp APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Could not parse JSON error response: %v. Body: %s", err, rr.Body.String())
+	}
+
+	expectedErrorSubstrings := []string{"No content added to PDF", "No images could be processed"}
+	foundError := false
+	for _, sub := range expectedErrorSubstrings {
+		if strings.Contains(resp.Error, sub) {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Errorf("handler returned unexpected error message for dummy file: got '%s', expected one of %v", resp.Error, expectedErrorSubstrings)
+	}
+}
+
+
+// TestHandleConvert_ContextCancellationDuringProcessing
+// This test is tricky because cancellation needs to happen *during* processing.
+// We can use a custom converter function that signals readiness and waits for cancellation.
+func TestHandleConvert_ContextCancellationDuringProcessing(t *testing.T) {
+	// Store the original converter function and defer its restoration
+	originalConvertToPDF := converter.ConvertToPDF
+	defer func() { converter.ConvertToPDF = originalConvertToPDF }()
+
+	ctxCancelledSignal := make(chan struct{})    // To signal the test that the context in handler was cancelled
+	proceedWithConversion := make(chan struct{}) // To signal the mock converter to proceed after delay
+
+	// Mock converter.ConvertToPDF
+	converter.ConvertToPDF = func(ctx context.Context, sources []converter.ImageSource, cfg *converter.Config, writer io.Writer) (bool, error) {
+		// Signal that conversion has started and is about to wait on context
+		slog.Debug("Mock ConvertToPDF started, waiting for context or proceed signal")
+		select {
+		case <-ctx.Done():
+			slog.Debug("Mock ConvertToPDF: context cancelled before proceeding.")
+			close(ctxCancelledSignal) // Signal that context was indeed cancelled
+			return false, ctx.Err()
+		case <-proceedWithConversion:
+			slog.Debug("Mock ConvertToPDF: Proceeding after signal (context not cancelled yet).")
+			// Simulate some work and then a successful conversion
+			fmt.Fprint(writer, "%PDF-1.4\n%%EOF\n") // Minimal PDF
+			return true, nil
+		case <-time.After(5 * time.Second): // Timeout for the mock converter itself
+			slog.Error("Mock ConvertToPDF: timed out waiting for context cancellation or proceed signal")
+			return false, errors.New("mock converter timeout")
+		}
+	}
+
+	// Prepare request
+	files := map[string]string{"images": "dummy.txt"} // Need at least one "image"
+	req := newFileUploadRequest(t, "/convert", nil, files)
+
+	// Create a context that we can cancel
+	reqCtx, cancelReqCtx := context.WithCancel(req.Context())
+	req = req.WithContext(reqCtx)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+
+	go func() {
+		// Simulate client cancelling the request after a short delay
+		// This delay should be long enough for the request to reach the mock converter,
+		// but short enough for the cancellation to occur while mock is "processing".
+		time.Sleep(100 * time.Millisecond)
+		slog.Debug("Test: Cancelling request context now.")
+		cancelReqCtx()
+	}()
+
+	handler.ServeHTTP(rr, req) // This will block until HandleConvert completes
+
+	// Check if the context was cancelled as expected by the mock
+	select {
+	case <-ctxCancelledSignal:
+		slog.Debug("Test: Mock converter confirmed context cancellation.")
+	case <-time.After(1 * time.Second):
+		// If mock didn't signal cancellation, try to proceed it to avoid deadlock if test fails
+		// then fail the test.
+		close(proceedWithConversion)
+		t.Error("Test: Mock converter did not signal context cancellation in time.")
+	}
+
+
+	// Expected status depends on when cancellation is caught.
+	// If caught by server/handler before PDF generation logic fully completes and writes headers,
+	// it might be 499 (if server supports it) or a timeout-like status.
+	// If caught by converter, HandleConvert should translate ctx.Err() to appropriate HTTP error.
+	// http.StatusGatewayTimeout (504) or http.StatusServiceUnavailable (503) are possibilities.
+	// For client cancellation, 499 is common but not standard. Let's check for 504 or 499 (though httptest might not show 499).
+	// Our handler maps context.Canceled to StatusGatewayTimeout.
+	if status := rr.Code; status != http.StatusGatewayTimeout {
+		t.Errorf("handler returned wrong status code for client cancellation: got %v want %v", status, http.StatusGatewayTimeout)
+		t.Logf("Response body: %s", rr.Body.String())
+	}
+
+	var resp APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Could not parse JSON error response: %v. Body: %s", err, rr.Body.String())
+	}
+	if !strings.Contains(resp.Error, "canceled") && !strings.Contains(resp.Error, "timed out") {
+		t.Errorf("Expected error message to indicate cancellation or timeout, got: %s", resp.Error)
+	}
+}
+
+
+// TestMain is used to create dummy files in testdata if they don't exist.
+func TestMain(m *testing.M) {
+	// Create api/testdata directory if it doesn't exist
+	testDataDir := "testdata"
+	if _, err := os.Stat(testDataDir); os.IsNotExist(err) {
+		os.Mkdir(testDataDir, 0755)
+	}
+
+	// Create a dummy text file to be used when actual images are not available/needed for a test.
+	dummyFilePath := filepath.Join(testDataDir, "dummy.txt")
+	if _, err := os.Stat(dummyFilePath); os.IsNotExist(err) {
+		err := os.WriteFile(dummyFilePath, []byte("This is a dummy file for API testing."), 0644)
+		if err != nil {
+			slog.Error("Failed to create dummy.txt for tests", "error", err)
+			os.Exit(1) // Abort tests if we can't create this essential dummy file
+		}
+	}
+	dummyApiTestFilePath := filepath.Join(testDataDir, "dummy_api_test_file.txt")
+	if _, err := os.Stat(dummyApiTestFilePath); os.IsNotExist(err) {
+		err := os.WriteFile(dummyApiTestFilePath, []byte("This is another dummy file for API testing."), 0644)
+		if err != nil {
+			slog.Error("Failed to create dummy_api_test_file.txt for tests", "error", err)
+			os.Exit(1)
+		}
+	}
+
+
+	// TODO: Add small, valid test.jpg, test.png, test.webp files to api/testdata
+	// For example:
+	// CreateDummyImage(filepath.Join(testDataDir, "test.jpg"), "jpg")
+	// CreateDummyImage(filepath.Join(testDataDir, "test.png"), "png")
+	// CreateDummyImage(filepath.Join(testDataDir, "test.webp"), "webp")
+	// These would be actual minimal valid image files.
+
+	// Run tests
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
+// Note: A TestHandleConvert_Success test would require:
+// 1. Actual small, valid image files (e.g., test.jpg, test.png, test.webp) in api/testdata.
+// 2. The converter.ConvertToPDF to actually work with these images and produce a PDF.
+// 3. Potentially, a way to validate the output PDF (e.g., check magic number, or use a PDF parsing library).
+// Example structure:
+/*
+func TestHandleConvert_Success(t *testing.T) {
+	// Ensure valid image files (e.g., test.jpg, test.png) are in api/testdata
+	files := map[string]string{
+		"images[]": "test.jpg", // Use actual image files
+		"images[]": "test.png",
+	}
+	// Optionally, add a URL to a known small public image
+	// server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { ... serve small image ... }))
+	// defer server.Close()
+	// urlsJSON := fmt.Sprintf(`["%s/some_image.webp"]`, server.URL)
+
+	params := map[string]string{
+		"config": `{"output_filename": "success.pdf"}`,
+		// "image_urls": urlsJSON, // If testing URLs
+	}
+
+	req := newFileUploadRequest(t, "/convert", params, files)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HandleConvert)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+		t.Logf("Response body: %s", rr.Body.String()) // Log error response if any
+		return
+	}
+
+	if contentType := rr.Header().Get("Content-Type"); contentType != "application/pdf" {
+		t.Errorf("handler returned wrong Content-Type: got %s want application/pdf", contentType)
+	}
+
+	if contentDisposition := rr.Header().Get("Content-Disposition"); !strings.Contains(contentDisposition, `filename="success.pdf"`) {
+		t.Errorf("handler returned wrong Content-Disposition: got %s want containing filename=\"success.pdf\"", contentDisposition)
+	}
+
+	if rr.Body.Len() == 0 {
+		t.Error("handler returned empty body for PDF")
+	}
+	// Optionally, check PDF magic number
+	// pdfMagicNumber := []byte("%PDF-")
+	// if !bytes.HasPrefix(rr.Body.Bytes(), pdfMagicNumber) {
+	// 	t.Error("Response body does not look like a PDF")
+	// }
+	t.Logf("Successfully received PDF of size %d bytes", rr.Body.Len())
+}
+*/

--- a/api/testdata/dummy.txt
+++ b/api/testdata/dummy.txt
@@ -1,0 +1,3 @@
+This is a dummy file for API testing purposes.
+It is not a valid image.
+For actual image upload tests, valid image files (e.g., a small JPG, PNG, WEBP) should be placed here.

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -1,0 +1,733 @@
+package converter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/draw" // Added for explicit conversion to NRGBA
+	_ "image/jpeg" // Added for JPEG decoding (register decoder)
+	_ "image/png"  // Added for PNG encoding (register decoder)
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/disintegration/imaging"
+	"github.com/jung-kurt/gofpdf"
+	_ "golang.org/x/image/webp" // Added for WebP decoding (register decoder)
+)
+
+// bufferPool is used to reuse byte buffers for WEBP to JPG conversion.
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+// ErrNoSupportedImages is returned when no supported image sources are provided or processed.
+var ErrNoSupportedImages = errors.New("no supported images were successfully processed")
+
+// ErrUnsupportedContentType is returned when an image URL points to an unsupported content type.
+var ErrUnsupportedContentType = errors.New("unsupported content type from URL")
+
+
+// ImageSource represents a single image to be processed.
+// It can be an uploaded file (via io.ReadCloser) or a URL (string).
+type ImageSource struct {
+	OriginalFilename string       // Original filename from upload or derived from URL
+	Reader           io.ReadCloser // Reader for the image data
+	URL              string       // URL if the image is to be fetched
+	ContentType      string       // Detected content type (e.g., "image/jpeg", "image/png", "image/webp")
+	Index            int          // Original index for ordering
+}
+
+// ProcessedImage holds the data for an image that has been processed and is ready for PDF registration.
+type ProcessedImage struct {
+	Index           int    // Original index of the file, for ordering
+	OriginalFilename string // Original filename
+	Error           error  // Error encountered during processing
+	Reader          io.Reader // Reader for image data (either *os.File or *bytes.Buffer)
+	Width           float64   // Width of the image in points
+	Height          float64   // Height of the image in points
+	ImageTypeForPDF string    // Type string for gofpdf ("PNG", "JPG")
+}
+
+// Config holds configuration for the conversion process.
+type Config struct {
+	JPEGQuality    int
+	NumWorkers     int
+	OutputFilename string // Suggested output filename, used for Content-Disposition
+	// InputDirectory is no longer needed here as images come from ImageSource list
+}
+
+// NewDefaultConfig creates a new Config with default values.
+func NewDefaultConfig() *Config {
+	return &Config{
+		JPEGQuality:    90,
+		NumWorkers:     runtime.NumCPU(),
+		OutputFilename: "converted.pdf",
+	}
+}
+
+// processSingleImage processes a single ImageSource.
+// It handles decoding based on ContentType and potential re-encoding for WebP.
+func processSingleImage(ctx context.Context, cfg *Config, source ImageSource) ProcessedImage {
+	slog.Debug("Starting to process image source", "originalFilename", source.OriginalFilename, "index", source.Index, "contentType", source.ContentType)
+	select {
+	case <-ctx.Done():
+		slog.Debug("Context cancelled before processing image source", "originalFilename", source.OriginalFilename)
+		if source.Reader != nil {
+			source.Reader.Close()
+		}
+		return ProcessedImage{Index: source.Index, OriginalFilename: source.OriginalFilename, Error: ctx.Err()}
+	default:
+	}
+
+	if source.Reader == nil {
+		slog.Warn("Image source reader is nil", "originalFilename", source.OriginalFilename)
+		return ProcessedImage{Index: source.Index, OriginalFilename: source.OriginalFilename, Error: errors.New("image reader is nil")}
+	}
+	defer source.Reader.Close()
+
+	processedInfo := ProcessedImage{Index: source.Index, OriginalFilename: source.OriginalFilename}
+	var imgConfig image.Config
+	var formatName string // Will store the detected format string from image.Decode/DecodeConfig
+	var err error
+
+	// Determine image type for gofpdf and processing path
+	var imageTypeForPDF string
+	var needsReEncoding bool
+
+	switch source.ContentType {
+	case "image/jpeg", "image/jpg":
+		imageTypeForPDF = "JPG"
+		needsReEncoding = false
+	case "image/png":
+		imageTypeForPDF = "PNG"
+		needsReEncoding = false
+	case "image/webp":
+		imageTypeForPDF = "JPG" // WebP will be converted to JPG for PDF
+		needsReEncoding = true
+	default:
+		// Try to decode config anyway, might be a known format with an unusual content type
+		slog.Warn("Potentially unsupported content type, attempting to decode", "contentType", source.ContentType, "filename", source.OriginalFilename)
+		// We need to "peek" at the format without consuming the reader for later full decode
+		// This is tricky. For now, let's assume if ContentType is not one of above, we try generic decode.
+		// A better way would be to use a TeeReader if we needed to DecodeConfig then Decode.
+		// However, since we decode directly or re-encode, we can just proceed.
+		img, detectedFormat, decodeErr := image.Decode(source.Reader)
+		if decodeErr != nil {
+			processedInfo.Error = fmt.Errorf("could not decode image (unknown content type %s) %s: %w", source.ContentType, source.OriginalFilename, decodeErr)
+			return processedInfo
+		}
+		formatName = detectedFormat
+		slog.Info("Decoded image with unknown initial content type", "detectedFormat", detectedFormat, "filename", source.OriginalFilename)
+
+		// Reset reader if possible (not possible for http body without buffering, this is a simplification)
+		// This part of the logic assumes source.Reader can be re-read or the 'img' is used directly.
+		// For API, the reader is likely a one-shot deal.
+		// If we decoded it, we must use the 'img' object.
+
+		switch detectedFormat {
+		case "jpeg":
+			imageTypeForPDF = "JPG"
+			needsReEncoding = false // It's already decoded, but we need to re-encode to pass to gofpdf if not JPG/PNG
+			// To avoid re-encoding if not necessary, we'd need to pass the raw stream.
+			// For simplicity now: if decoded, and it's JPEG, we'll re-encode to ensure it's in a buffer.
+			// This is a slight inefficiency for JPEGs that fell into this path.
+			buf := bufferPool.Get().(*bytes.Buffer)
+			buf.Reset()
+			if err := imaging.Encode(buf, img, imaging.JPEG, imaging.JPEGQuality(cfg.JPEGQuality)); err != nil {
+				bufferPool.Put(buf)
+				processedInfo.Error = fmt.Errorf("could not re-encode %s (originally %s) to jpg: %w", source.OriginalFilename, detectedFormat, err)
+				return processedInfo
+			}
+			processedInfo.Reader = buf
+			processedInfo.Width = float64(img.Bounds().Dx())
+			processedInfo.Height = float64(img.Bounds().Dy())
+			processedInfo.ImageTypeForPDF = "JPG"
+			slog.Debug("Successfully processed image (decoded from unknown type)", "filename", source.OriginalFilename, "originalFormat", formatName, "pdfType", imageTypeForPDF, "width", processedInfo.Width, "height", processedInfo.Height)
+			return processedInfo
+
+		case "png":
+			imageTypeForPDF = "PNG"
+			needsReEncoding = false // Similar to JPEG, re-encode to buffer for consistent handling
+			buf := bufferPool.Get().(*bytes.Buffer)
+			buf.Reset()
+			if err := imaging.Encode(buf, img, imaging.PNG); err != nil {
+				bufferPool.Put(buf)
+				processedInfo.Error = fmt.Errorf("could not re-encode %s (originally %s) to png: %w", source.OriginalFilename, detectedFormat, err)
+				return processedInfo
+			}
+			processedInfo.Reader = buf
+			processedInfo.Width = float64(img.Bounds().Dx())
+			processedInfo.Height = float64(img.Bounds().Dy())
+			processedInfo.ImageTypeForPDF = "PNG"
+			slog.Debug("Successfully processed image (decoded from unknown type)", "filename", source.OriginalFilename, "originalFormat", formatName, "pdfType", imageTypeForPDF, "width", processedInfo.Width, "height", processedInfo.Height)
+			return processedInfo
+		case "webp":
+			imageTypeForPDF = "JPG" // WebP will be converted to JPG for PDF
+			needsReEncoding = true // It's decoded, but needs re-encoding to JPG
+		default:
+			processedInfo.Error = fmt.Errorf("unsupported image format '%s' for %s (content type: %s)", detectedFormat, source.OriginalFilename, source.ContentType)
+			return processedInfo
+		}
+		// If we are here, it means we decoded 'img' and it's webp, or jpeg/png that needs re-encoding to buffer.
+		// Re-use the decoded 'img' for webp conversion or jpeg/png buffering.
+		if needsReEncoding { // True for WebP, or if we decided to re-encode for jpeg/png in this path
+			slog.Debug("Processing image that needs re-encoding", "filename", source.OriginalFilename, "originalFormat", formatName)
+			if formatName == "webp" { // Explicitly handle 16-bit WebP
+				switch img.(type) {
+				case *image.Gray16, *image.NRGBA64, *image.RGBA64:
+					slog.Debug("Converting 16-bit WebP image to 8-bit NRGBA", "filename", source.OriginalFilename)
+					img = imaging.Clone(img) // imaging.Clone converts to NRGBA
+				}
+			}
+			buf := bufferPool.Get().(*bytes.Buffer)
+			buf.Reset()
+			targetFormat := imaging.JPEG
+			if imageTypeForPDF == "PNG" { // Should not happen if needsReEncoding is true for PNG from unknown type
+				targetFormat = imaging.PNG
+			}
+
+			encodeOptions := []imaging.EncodeOption{}
+			if targetFormat == imaging.JPEG {
+				encodeOptions = append(encodeOptions, imaging.JPEGQuality(cfg.JPEGQuality))
+			}
+
+			if err := imaging.Encode(buf, img, targetFormat, encodeOptions...); err != nil {
+				bufferPool.Put(buf)
+				processedInfo.Error = fmt.Errorf("could not re-encode %s (format %s) to %s: %w", source.OriginalFilename, formatName, imageTypeForPDF, err)
+				return processedInfo
+			}
+			processedInfo.Reader = buf
+			processedInfo.Width = float64(img.Bounds().Dx())
+			processedInfo.Height = float64(img.Bounds().Dy())
+			processedInfo.ImageTypeForPDF = imageTypeForPDF
+			slog.Debug("Successfully processed image (re-encoded)", "filename", source.OriginalFilename, "originalFormat", formatName, "pdfType", imageTypeForPDF, "width", processedInfo.Width, "height", processedInfo.Height)
+			return processedInfo
+		}
+		// Fallthrough if not handled, though logic above should cover it.
+		processedInfo.Error = fmt.Errorf("internal error processing image %s with detected format %s", source.OriginalFilename, formatName)
+		return processedInfo
+	}
+
+
+	// Standard path for known content types (JPG, PNG, WebP)
+	if !needsReEncoding { // JPG or PNG
+		slog.Debug("Processing as PNG/JPG (direct reader)", "filename", source.OriginalFilename)
+		// We need to pass the original reader to gofpdf for JPG/PNG.
+		// However, we also need the dimensions. DecodeConfig first.
+		// This means the reader might be consumed. We need a TeeReader or to buffer it.
+		// For simplicity, let's read into a buffer first. This is less memory efficient for large files
+		// but simplifies handling and ensures the reader can be used by gofpdf.
+
+		data, readErr := io.ReadAll(source.Reader)
+		if readErr != nil {
+			processedInfo.Error = fmt.Errorf("could not read image data for %s: %w", source.OriginalFilename, readErr)
+			return processedInfo
+		}
+
+		imgConfig, formatName, err = image.DecodeConfig(bytes.NewReader(data))
+		if err != nil {
+			processedInfo.Error = fmt.Errorf("could not decode image config for %s: %w", source.OriginalFilename, err)
+			return processedInfo
+		}
+
+		processedInfo.Reader = bytes.NewReader(data) // Pass the buffered data
+		processedInfo.Width = float64(imgConfig.Width)
+		processedInfo.Height = float64(imgConfig.Height)
+		processedInfo.ImageTypeForPDF = imageTypeForPDF
+	} else { // WebP
+		slog.Debug("Processing as WEBP (decode and re-encode to JPG)", "filename", source.OriginalFilename)
+		decodedImg, webpFormatName, err := image.Decode(source.Reader)
+		if err != nil {
+			processedInfo.Error = fmt.Errorf("could not decode webp image %s: %w", source.OriginalFilename, err)
+			return processedInfo
+		}
+		formatName = webpFormatName // Store the actual decoded format name
+
+		// Handle 16-bit depth WebP by converting to 8-bit NRGBA before JPEG encoding
+		switch decodedImg.(type) {
+		case *image.Gray16, *image.NRGBA64, *image.RGBA64:
+			slog.Debug("Converting 16-bit WebP image to 8-bit NRGBA", "filename", source.OriginalFilename)
+			// imaging.Clone converts to NRGBA which is 8-bit per channel
+			decodedImg = imaging.Clone(decodedImg)
+		}
+
+		buf := bufferPool.Get().(*bytes.Buffer)
+		buf.Reset()
+		if err := imaging.Encode(buf, decodedImg, imaging.JPEG, imaging.JPEGQuality(cfg.JPEGQuality)); err != nil {
+			bufferPool.Put(buf)
+			processedInfo.Error = fmt.Errorf("could not re-encode webp %s to jpg: %w", source.OriginalFilename, err)
+			return processedInfo
+		}
+		processedInfo.Reader = buf
+		processedInfo.Width = float64(decodedImg.Bounds().Dx())
+		processedInfo.Height = float64(decodedImg.Bounds().Dy())
+		processedInfo.ImageTypeForPDF = "JPG" // Always JPG for WebP
+	}
+
+	slog.Debug("Successfully processed image", "filename", source.OriginalFilename, "originalFormat", formatName, "pdfType", imageTypeForPDF, "width", processedInfo.Width, "height", processedInfo.Height)
+	return processedInfo
+}
+
+
+// processImagesConcurrently processes a list of ImageSource concurrently.
+func processImagesConcurrently(ctx context.Context, cfg *Config, imageSources []ImageSource) []ProcessedImage {
+	slog.Debug("Starting concurrent image processing", "numSources", len(imageSources), "numWorkers", cfg.NumWorkers)
+	if len(imageSources) == 0 {
+		return []ProcessedImage{}
+	}
+
+	processedImageChan := make(chan ProcessedImage, len(imageSources)) // Buffered channel
+	semaphoreChan := make(chan struct{}, cfg.NumWorkers)
+	var wg sync.WaitGroup
+	results := make([]ProcessedImage, len(imageSources))
+
+	for i, source := range imageSources {
+		select {
+		case <-ctx.Done():
+			slog.Info("Cancellation detected before starting all goroutines for image sources", "lastProcessedIndex", i-1, "filename", source.OriginalFilename)
+			// Mark remaining as cancelled
+			for j := i; j < len(imageSources); j++ {
+				if results[j].OriginalFilename == "" { // Check if not already processed by a fast finishing goroutine
+					results[j] = ProcessedImage{Index: imageSources[j].Index, OriginalFilename: imageSources[j].OriginalFilename, Error: ctx.Err()}
+					if imageSources[j].Reader != nil {
+						imageSources[j].Reader.Close() // Ensure readers are closed
+					}
+				}
+			}
+			goto endGoroutineLoop // Break out of the loop
+		default:
+		}
+
+		wg.Add(1)
+		go func(src ImageSource) {
+			defer wg.Done()
+			slog.Debug("Goroutine started for image source", "filename", src.OriginalFilename, "index", src.Index)
+			select {
+			case semaphoreChan <- struct{}{}:
+				defer func() { <-semaphoreChan }()
+			case <-ctx.Done():
+				slog.Debug("Cancellation detected before acquiring semaphore for image source", "filename", src.OriginalFilename)
+				if src.Reader != nil {
+					src.Reader.Close()
+				}
+				processedImageChan <- ProcessedImage{Index: src.Index, OriginalFilename: src.OriginalFilename, Error: ctx.Err()}
+				return
+			}
+
+			// Check context again before potentially long operation
+			select {
+			case <-ctx.Done():
+				slog.Debug("Cancellation detected just before processing image source", "filename", src.OriginalFilename)
+				if src.Reader != nil {
+					src.Reader.Close()
+				}
+				processedImageChan <- ProcessedImage{Index: src.Index, OriginalFilename: src.OriginalFilename, Error: ctx.Err()}
+				return
+			default:
+				processedResult := processSingleImage(ctx, cfg, src) // src.Reader is closed by processSingleImage
+				select {
+				case processedImageChan <- processedResult:
+				case <-ctx.Done():
+					slog.Debug("Cancellation detected while trying to send result for image source", "filename", src.OriginalFilename)
+					// If result was successful but now cancelled, update error
+					if processedResult.Error == nil {
+						processedResult.Error = ctx.Err()
+					}
+					// Clean up reader if it wasn't closed due to early exit in processSingleImage
+					if closer, ok := processedResult.Reader.(io.Closer); ok {
+						closer.Close()
+					} else if buf, ok := processedResult.Reader.(*bytes.Buffer); ok {
+						bufferPool.Put(buf)
+					}
+					// Attempt to send anyway for accounting, or it might block wg.Wait if channel is full and main routine exited.
+					// However, with buffered channel and proper draining, this might not be strictly necessary.
+					// For safety, try non-blocking send or ensure channel is drained.
+					// Since channel is buffered to len(imageSources), this send should not block.
+					processedImageChan <- processedResult
+				}
+			}
+		}(source)
+	}
+
+endGoroutineLoop:
+
+	go func() {
+		wg.Wait()
+		close(processedImageChan)
+		close(semaphoreChan) // Close semaphore channel once all workers are done
+		slog.Debug("All image processing goroutines completed.")
+	}()
+
+	// Collect results
+	// Initialize results with a placeholder to detect if a slot was filled
+	for i := range results {
+		results[i].Index = -1 // Mark as not filled
+	}
+
+	for res := range processedImageChan {
+		if res.Index >= 0 && res.Index < len(results) {
+			results[res.Index] = res
+		} else {
+			slog.Error("Received processed image with out-of-bounds index", "index", res.Index, "filename", res.OriginalFilename)
+			// Clean up resources if any, though processSingleImage should handle its own.
+			if res.Error == nil { // If no error but bad index, still clean up reader
+				if closer, ok := res.Reader.(io.Closer); ok {
+					closer.Close()
+				} else if buf, ok := res.Reader.(*bytes.Buffer); ok {
+					bufferPool.Put(buf)
+				}
+			}
+		}
+	}
+
+	// Ensure all results slots are filled, especially if cancellation happened early
+	if ctx.Err() != nil {
+		for i, src := range imageSources {
+			// Check if the result for this index was not set or was set but then processing was cancelled
+			// If results[src.Index] is still the initial placeholder or has no error yet.
+			// src.Index should be the correct one.
+			if src.Index >=0 && src.Index < len(results) && (results[src.Index].Index == -1 || results[src.Index].OriginalFilename == "" ) {
+				results[src.Index] = ProcessedImage{Index: src.Index, OriginalFilename: src.OriginalFilename, Error: ctx.Err()}
+			} else if src.Index >=0 && src.Index < len(results) && results[src.Index].Error == nil {
+				// If it was processed but context cancelled during collection, ensure error is set
+				results[src.Index].Error = ctx.Err()
+				// Clean up associated reader if it exists and is not already closed
+				if closer, ok := results[src.Index].Reader.(io.Closer); ok {
+					closer.Close()
+				} else if buf, ok := results[src.Index].Reader.(*bytes.Buffer); ok {
+					bufferPool.Put(buf)
+				}
+				results[src.Index].Reader = nil // Nullify reader as it's unusable
+			}
+		}
+	}
+
+
+	slog.Debug("Finished collecting image processing results.")
+	return results
+}
+
+
+// generatePDFFromProcessedImages generates a PDF from a slice of ProcessedImage.
+// The writer `w` is where the PDF output will be written.
+func generatePDFFromProcessedImages(ctx context.Context, writer io.Writer, processedImages []ProcessedImage, pdf *gofpdf.Fpdf) (hasContent bool, err error) {
+	slog.Debug("Starting PDF generation from processed images", "numImages", len(processedImages))
+	hasContent = false
+
+	// Sort processedImages by original index to ensure correct order in PDF
+	sort.SliceStable(processedImages, func(i, j int) bool {
+		return processedImages[i].Index < processedImages[j].Index
+	})
+
+	for i, res := range processedImages {
+		select {
+		case <-ctx.Done():
+			slog.Info("Cancellation detected before adding image to PDF", "filename", res.OriginalFilename)
+			// Clean up reader if processing was successful but cancelled here
+			if res.Error == nil {
+				if closer, ok := res.Reader.(io.Closer); ok {
+					closer.Close()
+				} else if buf, ok := res.Reader.(*bytes.Buffer); ok {
+					bufferPool.Put(buf)
+				}
+			}
+			return hasContent, ctx.Err()
+		default:
+		}
+
+		if res.Error != nil {
+			if errors.Is(res.Error, context.Canceled) {
+				slog.Debug("Skipping image due to earlier cancellation", "filename", res.OriginalFilename)
+			} else {
+				slog.Warn("Skipping image due to error during its processing", "filename", res.OriginalFilename, "error", res.Error)
+			}
+			// Ensure any associated reader/buffer is cleaned up if an error occurred during processing
+			if closer, ok := res.Reader.(io.Closer); ok {
+				closer.Close()
+			} else if buf, ok := res.Reader.(*bytes.Buffer); ok {
+				bufferPool.Put(buf)
+			}
+			continue
+		}
+		if res.Reader == nil {
+			slog.Warn("Reader for image is nil, skipping", "filename", res.OriginalFilename)
+			continue
+		}
+
+		slog.Debug("Adding image to PDF", "filename", res.OriginalFilename, "width", res.Width, "height", res.Height, "type", res.ImageTypeForPDF)
+
+		// Ensure the reader is handled correctly (closed or buffer returned to pool)
+		readerToClean := res.Reader
+		defer func(r io.Reader) {
+			if fCloser, ok := r.(*os.File); ok { // Should not happen with API based sources
+				fCloser.Close()
+			} else if bReader, ok := r.(*bytes.Buffer); ok {
+				bufferPool.Put(bReader)
+			} else if rc, ok := r.(io.ReadCloser); ok { // Generic ReadCloser from ImageSource after processing
+				rc.Close()
+			}
+		}(readerToClean)
+
+
+		pdf.AddPageFormat("P", gofpdf.SizeType{Wd: res.Width, Ht: res.Height})
+		if pdf.Err() {
+			slog.Warn("Could not add page to PDF for image", "filename", res.OriginalFilename, "error", pdf.Error())
+			pdf.ClearError()
+			continue // Skip this image
+		}
+
+		imageName := fmt.Sprintf("image%d_%d", res.Index, i) // Ensure unique name
+		// Use res.Reader directly. It's either a *bytes.Buffer (for webp/re-encoded) or a *bytes.Reader (for direct jpg/png)
+		pdf.RegisterImageOptionsReader(imageName, gofpdf.ImageOptions{ImageType: res.ImageTypeForPDF, ReadDpi: false}, res.Reader)
+
+		if pdf.Err() {
+			slog.Warn("Could not register image in PDF", "filename", res.OriginalFilename, "error", pdf.Error())
+			pdf.ClearError()
+			continue // Skip this image
+		}
+
+		pdf.ImageOptions(imageName, 0, 0, res.Width, res.Height, false, gofpdf.ImageOptions{ImageType: res.ImageTypeForPDF}, 0, "")
+		if pdf.Err() {
+			slog.Warn("Could not place image on PDF page", "filename", res.OriginalFilename, "error", pdf.Error())
+			pdf.ClearError()
+			continue // Skip this image
+		}
+		hasContent = true
+		slog.Debug("Successfully added image to PDF", "filename", res.OriginalFilename)
+	}
+
+	if pdf.Err() { // Check for any accumulated errors in gofpdf
+		return hasContent, fmt.Errorf("error generating PDF structure: %w", pdf.Error())
+	}
+
+	select {
+	case <-ctx.Done():
+		slog.Info("Cancellation detected before writing PDF output.")
+		return hasContent, ctx.Err()
+	default:
+	}
+
+	if hasContent {
+		slog.Debug("Writing PDF to output stream...")
+		if err := pdf.Output(writer); err != nil {
+			return true, fmt.Errorf("could not write PDF to writer: %w", err)
+		}
+		slog.Debug("Successfully wrote PDF to output stream.")
+	} else {
+		if ctx.Err() != nil { // If context was cancelled, and no content, return context error
+			return false, ctx.Err()
+		}
+		// If no content but also no cancellation, it means all images failed or were skipped.
+		if len(processedImages) > 0 {
+			slog.Info("No content was added to the PDF (all images skipped or failed).")
+		} else {
+			slog.Info("No images processed and no content to add to PDF.")
+		}
+	}
+	return hasContent, nil
+}
+
+// ConvertToPDF is the main entry point for the converter package.
+// It takes a context, a list of ImageSource, a Config, and an io.Writer for the PDF output.
+// It returns true if content was added to the PDF, and an error if one occurred.
+func ConvertToPDF(ctx context.Context, sources []ImageSource, cfg *Config, writer io.Writer) (hasContent bool, err error) {
+	slog.Debug("Starting PDF conversion process via converter package", "numSources", len(sources))
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
+	if len(sources) == 0 {
+		slog.Info("No image sources provided for conversion.")
+		return false, ErrNoSupportedImages
+	}
+
+	// Filter out sources that are obviously invalid before concurrent processing
+	validSources := make([]ImageSource, 0, len(sources))
+	for _, src := range sources {
+		if src.Reader == nil && src.URL == "" {
+			slog.Warn("Skipping image source with no reader and no URL", "originalFilename", src.OriginalFilename, "index", src.Index)
+			// Potentially create a ProcessedImage with an error for this source if strict result parity is needed.
+			// For now, just skip. The API handler will be responsible for creating valid ImageSource objects.
+			continue
+		}
+		validSources = append(validSources, src)
+	}
+
+	if len(validSources) == 0 {
+		slog.Info("No valid image sources after filtering.")
+		// Close any readers from the original sources list if they were opened by the caller
+		// (though the API handler should manage this lifecycle)
+		for _, src := range sources {
+			if src.Reader != nil {
+				src.Reader.Close()
+			}
+		}
+		return false, ErrNoSupportedImages
+	}
+
+	slog.Info("Processing valid image sources", "count", len(validSources))
+
+	pdf := gofpdf.New("P", "pt", "A4", "") // Default page size, actual size set per image
+
+	// Process images concurrently
+	processedImageInfos := processImagesConcurrently(ctx, cfg, validSources)
+
+	// Ensure all readers from original sources that might not have been consumed by
+	// processImagesConcurrently (e.g. due to early cancellation) are closed.
+	// processSingleImage is responsible for closing readers it processes.
+	// Goroutines in processImagesConcurrently also attempt to close readers on cancellation.
+	// This is a final safeguard.
+	processedIndexes := make(map[int]bool)
+	for _, pInfo := range processedImageInfos {
+		processedIndexes[pInfo.Index] = true
+	}
+	for _, src := range validSources {
+		if !processedIndexes[src.Index] && src.Reader != nil {
+			// This source was intended for processing but didn't make it into processedImageInfos
+			// or its goroutine exited very early.
+			slog.Debug("Closing reader for unprocessed or early-cancelled source", "filename", src.OriginalFilename, "index", src.Index)
+			src.Reader.Close()
+		}
+	}
+
+
+	select {
+	case <-ctx.Done():
+		slog.Info("Cancellation detected before PDF generation phase in ConvertToPDF.")
+		// Clean up any readers from successfully processed images that won't be used
+		for _, info := range processedImageInfos {
+			if info.Error == nil || !errors.Is(info.Error, context.Canceled) {
+				if closer, ok := info.Reader.(io.Closer); ok {
+					closer.Close()
+				} else if buf, ok := info.Reader.(*bytes.Buffer); ok {
+					bufferPool.Put(buf)
+				}
+			}
+		}
+		return false, ctx.Err()
+	default:
+	}
+
+	// Generate PDF from processed images
+	contentAdded, genErr := generatePDFFromProcessedImages(ctx, writer, processedImageInfos, pdf)
+	if genErr != nil {
+		if errors.Is(genErr, context.Canceled) {
+			slog.Info("PDF generation was canceled.")
+			return contentAdded, context.Canceled // Return contentAdded status along with cancellation
+		}
+		slog.Error("Failed during PDF generation", "error", genErr)
+		return contentAdded, fmt.Errorf("pdf generation failed: %w", genErr)
+	}
+
+	if !contentAdded && len(validSources) > 0 {
+		// Check if any processed image had an error OTHER than cancellation.
+		// If all errors are cancellations, then the overall status is cancellation.
+		// If there are other errors, it's more like "no content due to errors".
+		allCancelled := true
+		hasOtherErrors := false
+		for _, pInfo := range processedImageInfos {
+			if pInfo.Error != nil {
+				if !errors.Is(pInfo.Error, context.Canceled) {
+					allCancelled = false
+					hasOtherErrors = true
+					break
+				}
+			} else {
+				// If an image was processed successfully but not added (e.g. PDF error for that specific image)
+				// this also means not all were cancelled.
+				allCancelled = false
+			}
+		}
+		if ctx.Err() != nil { // Global context cancellation
+			return false, ctx.Err()
+		}
+		if allCancelled && !hasOtherErrors && len(processedImageInfos) > 0 { // All were attempted but cancelled
+			return false, context.Canceled // Or a more specific error if needed
+		}
+		// If no content and not due to cancellation of all items, return ErrNoSupportedImages
+		return false, ErrNoSupportedImages
+	}
+
+	slog.Info("PDF conversion process completed", "contentAdded", contentAdded)
+	return contentAdded, nil
+}
+
+// Helper function to determine content type from file extension
+// This is a fallback if http.DetectContentType is not sufficient or not available (e.g. from filename only)
+func GetContentTypeFromFilename(filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+	switch ext {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	default:
+		return "" // Unknown
+	}
+}
+
+// FetchImage downloads an image from a URL.
+// It returns an ImageSource with the Reader populated, or an error.
+// The caller is responsible for closing the ImageSource.Reader.
+func FetchImage(ctx context.Context, imageURL string, index int) (ImageSource, error) {
+	slog.Debug("Fetching image from URL", "url", imageURL, "index", index)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", imageURL, nil)
+	if err != nil {
+		slog.Error("Failed to create request for URL", "url", imageURL, "error", err)
+		return ImageSource{}, fmt.Errorf("failed to create request for %s: %w", imageURL, err)
+	}
+
+	client := &http.Client{} // Consider customizing timeout
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("Failed to fetch image from URL", "url", imageURL, "error", err)
+		return ImageSource{}, fmt.Errorf("failed to fetch %s: %w", imageURL, err)
+	}
+	// Caller must close resp.Body via ImageSource.Reader.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		slog.Warn("Failed to fetch image, non-OK status", "url", imageURL, "status", resp.StatusCode)
+		return ImageSource{}, fmt.Errorf("failed to fetch %s: status %s", imageURL, resp.Status)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	// Basic validation of content type
+	if !strings.HasPrefix(strings.ToLower(contentType), "image/") {
+		resp.Body.Close()
+		slog.Warn("Unsupported content type from URL", "url", imageURL, "contentType", contentType)
+		return ImageSource{}, fmt.Errorf("%w: %s from %s", ErrUnsupportedContentType, contentType, imageURL)
+	}
+
+	// Try to get a filename from URL
+	filename := filepath.Base(imageURL)
+	parsedURL, parseErr := http.ParseRequestURI(imageURL)
+	if parseErr == nil {
+		filename = filepath.Base(parsedURL.Path)
+	}
+
+
+	return ImageSource{
+		OriginalFilename: filename,
+		Reader:           resp.Body, // This is an io.ReadCloser
+		URL:              imageURL,
+		ContentType:      contentType,
+		Index:            index,
+	}, nil
+}

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -1,0 +1,410 @@
+package converter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Helper to create a dummy ImageSource with a string reader
+func newStringImageSource(name, content, contentType string, index int) ImageSource {
+	return ImageSource{
+		OriginalFilename: name,
+		Reader:           io.NopCloser(strings.NewReader(content)),
+		ContentType:      contentType,
+		Index:            index,
+	}
+}
+
+// Helper to create a dummy ImageSource from a file
+func newFileImageSource(t *testing.T, filename, contentType string, index int) ImageSource {
+	t.Helper()
+	// Use a real small image if available, otherwise a dummy text file
+	path := filepath.Join("testdata", filename)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// Create a dummy file if it doesn't exist, for basic testing
+		dummyPath := filepath.Join("testdata", "dummy_test_file.txt")
+		_ = os.WriteFile(dummyPath, []byte("dummy content for "+filename), 0644)
+		path = dummyPath
+		slog.Warn("Test image file not found, using dummy", "path", filepath.Join("testdata", filename))
+		// For real image processing tests, actual image files are needed.
+		// These tests might focus on flow rather than actual image decoding.
+	}
+
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Failed to open test file %s: %v", path, err)
+	}
+	return ImageSource{
+		OriginalFilename: filename,
+		Reader:           file, // This will be closed by the converter
+		ContentType:      contentType,
+		Index:            index,
+	}
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	cfg := NewDefaultConfig()
+	if cfg.JPEGQuality != 90 {
+		t.Errorf("Expected JPEGQuality 90, got %d", cfg.JPEGQuality)
+	}
+	if cfg.NumWorkers <= 0 {
+		t.Errorf("Expected NumWorkers > 0, got %d", cfg.NumWorkers)
+	}
+	if cfg.OutputFilename != "converted.pdf" {
+		t.Errorf("Expected OutputFilename 'converted.pdf', got %s", cfg.OutputFilename)
+	}
+}
+
+// Note: Testing processSingleImage thoroughly requires valid image data.
+// These tests will be basic, focusing on flow and error handling for non-image data.
+// To test actual image processing, place small valid jpg, png, webp files in testdata.
+func TestProcessSingleImage_InvalidData(t *testing.T) {
+	cfg := NewDefaultConfig()
+	ctx := context.Background()
+
+	// Use a source that is not a valid image format
+	source := newStringImageSource("invalid.txt", "this is not an image", "text/plain", 0)
+
+	// Redirect slog to a buffer to check logs if needed
+	var logBuf bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(originalLogger)
+
+	processedImg := processSingleImage(ctx, cfg, source)
+
+	if processedImg.Error == nil {
+		t.Errorf("Expected error for invalid image data, got nil. Logs: %s", logBuf.String())
+	} else {
+		t.Logf("Received expected error for invalid data: %v", processedImg.Error)
+	}
+	if processedImg.Reader != nil {
+		t.Error("Expected reader to be nil on error")
+		if closer, ok := processedImg.Reader.(io.Closer); ok {
+			closer.Close()
+		}
+	}
+}
+
+func TestProcessSingleImage_ContextCancellation(t *testing.T) {
+	cfg := NewDefaultConfig()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel context immediately
+
+	source := newStringImageSource("test.jpg", "dummy_jpeg_data", "image/jpeg", 0)
+	processedImg := processSingleImage(ctx, cfg, source)
+
+	if !errors.Is(processedImg.Error, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got %v", processedImg.Error)
+	}
+}
+
+func TestConvertToPDF_NoSources(t *testing.T) {
+	cfg := NewDefaultConfig()
+	ctx := context.Background()
+	var writer bytes.Buffer
+
+	hasContent, err := ConvertToPDF(ctx, []ImageSource{}, cfg, &writer)
+
+	if err == nil {
+		t.Error("Expected error for no sources, got nil")
+	} else if !errors.Is(err, ErrNoSupportedImages) {
+		t.Errorf("Expected ErrNoSupportedImages, got %v", err)
+	}
+
+	if hasContent {
+		t.Error("Expected no content when no sources are provided")
+	}
+	if writer.Len() > 0 {
+		t.Errorf("Expected empty PDF output, got %d bytes", writer.Len())
+	}
+}
+
+func TestConvertToPDF_AllSourcesError(t *testing.T) {
+	cfg := NewDefaultConfig()
+	ctx := context.Background()
+	var writer bytes.Buffer
+
+	sources := []ImageSource{
+		newStringImageSource("invalid1.txt", "not image", "text/plain", 0),
+		newStringImageSource("invalid2.txt", "not image", "text/plain", 1),
+	}
+
+	hasContent, err := ConvertToPDF(ctx, sources, cfg, &writer)
+
+	if err == nil {
+		t.Error("Expected error when all sources fail, got nil")
+	} else if !errors.Is(err, ErrNoSupportedImages) { // This is the current behavior
+		t.Errorf("Expected ErrNoSupportedImages or similar, got %v", err)
+	}
+
+
+	if hasContent {
+		t.Error("Expected no content when all sources fail")
+	}
+}
+
+func TestConvertToPDF_ContextCancellation(t *testing.T) {
+	cfg := NewDefaultConfig()
+	ctx, cancel := context.WithCancel(context.Background())
+	var writer bytes.Buffer
+
+	// Create a source that would normally succeed if not for cancellation
+	// For this test, we'll use a dummy file source.
+	// Ensure 'dummy.jpg' exists in 'testdata' or is created by newFileImageSource's fallback.
+	sources := []ImageSource{
+		newFileImageSource(t, "dummy.jpg", "image/jpeg", 0),
+	}
+
+	cancel() // Cancel context before calling
+
+	hasContent, err := ConvertToPDF(ctx, sources, cfg, &writer)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got %v", err)
+	}
+	if hasContent {
+		t.Error("Expected no content with immediate cancellation")
+	}
+}
+
+// This test requires a running HTTP server for FetchImage.
+// We'll use httptest.NewServer.
+func TestFetchImage_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		fmt.Fprint(w, "fake_jpeg_data")
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	imgSrc, err := FetchImage(ctx, server.URL, 0)
+	if err != nil {
+		t.Fatalf("FetchImage failed: %v", err)
+	}
+	defer imgSrc.Reader.Close()
+
+	if imgSrc.ContentType != "image/jpeg" {
+		t.Errorf("Expected content type image/jpeg, got %s", imgSrc.ContentType)
+	}
+	if imgSrc.OriginalFilename == "" {
+		t.Error("Expected a filename to be derived from URL")
+	}
+	data, _ := io.ReadAll(imgSrc.Reader)
+	if string(data) != "fake_jpeg_data" {
+		t.Errorf("Expected 'fake_jpeg_data', got '%s'", string(data))
+	}
+}
+
+func TestFetchImage_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	_, err := FetchImage(ctx, server.URL, 0)
+	if err == nil {
+		t.Fatal("Expected error for 404 Not Found, got nil")
+	}
+	t.Logf("Received expected error for 404: %v", err)
+}
+
+func TestFetchImage_UnsupportedContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html></html>")
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	imgSrc, err := FetchImage(ctx, server.URL, 0)
+	if err == nil {
+		imgSrc.Reader.Close() // Close reader if FetchImage unexpectedly succeeded
+		t.Fatal("Expected error for unsupported content type, got nil")
+	}
+	if !errors.Is(err, ErrUnsupportedContentType) {
+		t.Errorf("Expected ErrUnsupportedContentType, got %v", err)
+	}
+	t.Logf("Received expected error for unsupported content type: %v", err)
+}
+
+func TestFetchImage_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond) // Ensure request starts
+		fmt.Fprint(w, "slow_response")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel before request can complete
+
+	_, err := FetchImage(ctx, server.URL, 0)
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		// Error might be wrapped, so check string too
+		t.Errorf("Expected context.Canceled error, got %v", err)
+	}
+}
+
+
+// TestProcessImagesConcurrently_OrderAndCancellation
+// This test is more complex as it involves concurrency and timing.
+func TestProcessImagesConcurrently_OrderAndCancellation(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.NumWorkers = 2 // Control number of workers for predictability
+
+	// Create some dummy sources.
+	// processSingleImage will likely error out on these as they are not real images.
+	// The focus here is on the orchestration by processImagesConcurrently.
+	sources := []ImageSource{
+		newStringImageSource("img0.txt", "data0", "text/plain", 0),
+		newStringImageSource("img1.txt", "data1", "text/plain", 1),
+		newStringImageSource("img2.txt", "data2", "text/plain", 2),
+		newStringImageSource("img3.txt", "data3", "text/plain", 3),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1) // For the main processing goroutine
+
+	var results []ProcessedImage
+	go func() {
+		defer wg.Done()
+		results = processImagesConcurrently(ctx, cfg, sources)
+	}()
+
+	// Allow some processing to start, then cancel
+	time.Sleep(50 * time.Millisecond) // Small delay
+	cancel()
+	wg.Wait() // Wait for processImagesConcurrently to finish
+
+	if len(results) != len(sources) {
+		t.Fatalf("Expected %d results, got %d", len(sources), len(results))
+	}
+
+	cancelledCount := 0
+	for i, res := range results {
+		if res.Index != sources[i].Index {
+			// This check assumes results are implicitly ordered by source input order before explicit sort.
+			// processImagesConcurrently populates a slice of the same length, so res.Index should map to original.
+			// The final sort in generatePDFFromProcessedImages is what matters for PDF.
+			// Let's check if all original indices are present.
+		}
+		if res.Error != nil {
+			if errors.Is(res.Error, context.Canceled) {
+				cancelledCount++
+			} else {
+				// If it's not a cancellation error, it's likely a processing error due to dummy data
+				t.Logf("Result for index %d has non-cancellation error: %v (expected due to dummy data or cancellation)", res.Index, res.Error)
+			}
+		} else {
+			// This shouldn't happen with dummy text data if processSingleImage is strict.
+			// Or if cancellation was too fast.
+			t.Logf("Result for index %d has no error, but context was cancelled.", res.Index)
+		}
+	}
+
+	if cancelledCount == 0 && len(sources) > 0 {
+		t.Errorf("Expected some images to be marked as cancelled, but none were. Total results: %d", len(results))
+	} else {
+		t.Logf("%d images were marked with cancellation error or processing error.", cancelledCount)
+	}
+	// This test is more of a sanity check for the concurrent processing logic with cancellation.
+	// Precise number of cancelled vs processed-with-error can vary based on timing.
+}
+
+
+// To properly test ConvertToPDF with actual PDF generation, you'd need:
+// 1. Valid small image files (jpg, png, webp).
+// 2. A way to inspect the generated PDF (e.g., check page count, or if it's a valid PDF).
+//    This often requires external libraries or is very basic (like checking for PDF magic numbers).
+
+// For now, we'll assume that if no error occurs and hasContent is true, it's a basic success.
+// Place `test.jpg`, `test.png`, `test.webp` (valid, small images) in `testdata/` for this to work.
+func TestConvertToPDF_WithValidDummyImages(t *testing.T) {
+	// Create dummy valid image files in testdata if they don't exist
+	// For this test, we rely on newFileImageSource's fallback to dummy text files.
+	// The converter will error on these, so this test will be similar to AllSourcesError.
+	// To make this a true success test, you need REAL images.
+
+	td := t.TempDir()
+	// Create dummy files that are NOT valid images but pass os.Stat
+	_ = os.WriteFile(filepath.Join(td, "test.jpg"), []byte("dummy jpg"), 0644)
+	_ = os.WriteFile(filepath.Join(td, "test.png"), []byte("dummy png"), 0644)
+
+	// Override testdata path for newFileImageSource for this test
+	originalTestDataPath := "testdata"
+	defer func() {
+		// This is a bit hacky; ideally, newFileImageSource would take the base path.
+		// For now, we know it prepends "testdata". This won't work as intended
+		// without modifying newFileImageSource or creating files in the actual ./testdata
+		// For this self-contained example, let's assume newFileImageSource will use its fallback.
+		// The test will then behave like AllSourcesError.
+	}()
+	// If actual files 'test.jpg', 'test.png' are in ./testdata, this test becomes more meaningful.
+	// For CI, ensure these files are present.
+
+	cfg := NewDefaultConfig()
+	ctx := context.Background()
+	var writer bytes.Buffer
+
+	sources := []ImageSource{
+		newFileImageSource(t, "test.jpg", "image/jpeg", 0), // Will use dummy_test_file.txt if test.jpg not found
+		newFileImageSource(t, "test.png", "image/png", 1), // Will use dummy_test_file.txt if test.png not found
+	}
+
+	hasContent, err := ConvertToPDF(ctx, sources, cfg, &writer)
+
+	// Given that these are dummy text files, processSingleImage will error out.
+	// So, ConvertToPDF should return an error and no content.
+	if err == nil {
+		t.Errorf("Expected error with dummy (non-image) files, got nil. PDF size: %d", writer.Len())
+		if writer.Len() > 0 {
+			// You could try to save this to inspect it:
+			// os.WriteFile("error_dummy_output.pdf", writer.Bytes(), 0644)
+		}
+	} else if !errors.Is(err, ErrNoSupportedImages) {
+		t.Errorf("Expected ErrNoSupportedImages with dummy files, got %v", err)
+	}
+
+	if hasContent {
+		t.Error("Expected no content with dummy (non-image) files")
+	}
+}
+
+
+func TestGetContentTypeFromFilename(t *testing.T) {
+	tests := []struct {
+		filename string
+		expected string
+	}{
+		{"image.jpg", "image/jpeg"},
+		{"image.JPEG", "image/jpeg"},
+		{"document.png", "image/png"},
+		{"animation.webp", "image/webp"},
+		{"archive.zip", ""},
+		{"unknown", ""},
+		{".bashrc", ""},
+	}
+
+	for _, tt := range tests {
+		got := GetContentTypeFromFilename(tt.filename)
+		if got != tt.expected {
+			t.Errorf("GetContentTypeFromFilename(%s): expected '%s', got '%s'", tt.filename, tt.expected, got)
+		}
+	}
+}

--- a/internal/converter/testdata/dummy.txt
+++ b/internal/converter/testdata/dummy.txt
@@ -1,0 +1,2 @@
+This is a dummy file for testing purposes.
+It is not a valid image.

--- a/main.go
+++ b/main.go
@@ -1,72 +1,41 @@
 package main
 
 import (
-	"bytes"
+	"context"
 	"errors"
-	"flag"
 	"fmt"
-	"github.com/disintegration/imaging" // Added for image conversion
-	"github.com/jung-kurt/gofpdf"
-	_ "golang.org/x/image/webp" // Added for WebP decoding (register decoder)
-	"image"                     // Added for image manipulation
-	"context" // Added for graceful shutdown
-	"image/draw"                // Added for explicit conversion to NRGBA
-	_ "image/jpeg"              // Added for JPEG decoding (register decoder)
-	_ "image/png"               // Added for PNG encoding (register decoder)
-	"io"
-	"log/slog" // Standard library structured logging
+	"log/slog"
+	"net/http"
 	"os"
-	"os/signal" // Added for graceful shutdown
-	"path/filepath"
-	"runtime" // Added for memory profiling
-	"runtime/pprof" // Added for CPU and memory profiling
-	"sort"
-	"strings"
-	"sync" // Added for sync.Pool
+	"os/signal"
+	"syscall" // For SIGTERM
+	"time"
+
+	"manga_to_pdf/api" // Import the new api package
+	// "manga_to_pdf/internal/converter" // No longer directly needed by main
 )
 
-// bufferPool is used to reuse byte buffers for WEBP to JPG conversion.
-var bufferPool = sync.Pool{
-	New: func() interface{} {
-		return new(bytes.Buffer)
-	},
-}
-
-// ErrNoSupportedFiles is returned when no supported image files are found in a directory.
-var ErrNoSupportedFiles = errors.New("no supported image files found")
-
-// ProcessedImage holds the data for an image that has been processed and is ready for PDF registration.
-type ProcessedImage struct {
-	Index           int    // Original index of the file, for ordering
-	Filename        string // Original filename
-	Error           error  // Error encountered during processing
-	Reader          io.Reader // Reader for image data (either *os.File or *bytes.Buffer)
-	Width           float64   // Width of the image in points
-	Height          float64   // Height of the image in points
-	ImageTypeForPDF string    // Type string for gofpdf ("PNG", "JPG")
-}
-
-// Config holds all application configuration.
+// Config holds all application configuration for the server.
 type Config struct {
-	InputDirectory string
-	OutputFilename string
-	CPUProfileFile string
-	MemProfileFile string
-	NumWorkers     int
-	JPEGQuality    int
+	ListenAddress  string
 	VerboseLogging bool
+	// CPUProfileFile string // Profiling can be added back if needed via HTTP endpoints (e.g. net/http/pprof)
+	// MemProfileFile string
 }
 
 func main() {
-	cfg := Config{}
-	flag.StringVar(&cfg.InputDirectory, "i", ".", "Input directory containing image files (.webp, .jpg, .jpeg, .png)")
-	flag.StringVar(&cfg.OutputFilename, "o", "output.pdf", "Output PDF file name")
-	flag.StringVar(&cfg.CPUProfileFile, "cpuprofile", "", "Write cpu profile to `file`")
-	flag.StringVar(&cfg.MemProfileFile, "memprofile", "", "Write memory profile to `file`")
-	flag.IntVar(&cfg.NumWorkers, "concurrency", runtime.NumCPU(), "Number of concurrent workers for image processing")
-	flag.IntVar(&cfg.JPEGQuality, "jpeg-quality", 90, "JPEG quality for WEBP conversion (1-100)")
-	flag.BoolVar(&cfg.VerboseLogging, "verbose", false, "Enable verbose/debug logging")
-	flag.Parse()
+	cfg := Config{
+		ListenAddress:  ":8080", // Default listen address
+		VerboseLogging: false,   // Default logging level
+	}
+
+	// Basic environment variable configuration (optional)
+	if addr := os.Getenv("LISTEN_ADDRESS"); addr != "" {
+		cfg.ListenAddress = addr
+	}
+	if verbose := os.Getenv("VERBOSE_LOGGING"); verbose == "true" || verbose == "1" {
+		cfg.VerboseLogging = true
+	}
 
 	// Setup structured logger
 	var logLevel slog.Level
@@ -78,474 +47,59 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 	slog.SetDefault(logger)
 
-	// Validate and apply defaults for config values
-	if cfg.NumWorkers <= 0 {
-		slog.Warn("Concurrency must be a positive number, defaulting to NumCPU", "provided", cfg.NumWorkers, "default", runtime.NumCPU())
-		cfg.NumWorkers = runtime.NumCPU()
-	}
-	if cfg.JPEGQuality < 1 || cfg.JPEGQuality > 100 {
-		slog.Warn("JPEG quality must be between 1 and 100, defaulting to 90", "provided", cfg.JPEGQuality, "default", 90)
-		cfg.JPEGQuality = 90
+	slog.Info("Starting API server...", "address", cfg.ListenAddress, "verbose_logging", cfg.VerboseLogging)
+
+	// Setup HTTP server and router
+	mux := http.NewServeMux()
+	mux.HandleFunc("/convert", api.HandleConvert) // Register the /convert handler
+
+	// Add health check endpoint
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"status":"ok"}`)
+	})
+
+	// Consider adding pprof endpoints for profiling if needed
+	// mux.HandleFunc("/debug/pprof/", pprof.Index)
+	// mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	// mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	// mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	// mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+
+	server := &http.Server{
+		Addr:    cfg.ListenAddress,
+		Handler: mux,
+		// ReadTimeout:  5 * time.Second, // Example: Add timeouts for security
+		// WriteTimeout: 60 * time.Second, // Example: Longer for PDF generation
+		// IdleTimeout:  120 * time.Second,
 	}
 
-	if cfg.CPUProfileFile != "" {
-		f, err := os.Create(cfg.CPUProfileFile)
-		if err != nil {
-			slog.Error("could not create CPU profile", "file", cfg.CPUProfileFile, "error", err)
-			os.Exit(1)
-		}
-		defer f.Close()
-		if err := pprof.StartCPUProfile(f); err != nil {
-			slog.Error("could not start CPU profile", "error", err)
-			os.Exit(1)
-		}
-		defer pprof.StopCPUProfile()
-		slog.Info("CPU profiling enabled", "file", cfg.CPUProfileFile)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
+	// Graceful shutdown
+	idleConnsClosed := make(chan struct{})
 	go func() {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 		sig := <-sigChan
 		slog.Info("Received signal, shutting down gracefully...", "signal", sig)
-		cancel()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // 30-second shutdown timeout
+		defer cancel()
+
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			slog.Error("HTTP server Shutdown error", "error", err)
+		}
+		slog.Info("HTTP server shutdown complete.")
+		close(idleConnsClosed)
 	}()
 
-	err := runApp(ctx, &cfg) // Pass pointer to Config
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			slog.Info("Process canceled by user. Output might be incomplete.")
-			os.Exit(130)
-		} else if !errors.Is(err, ErrNoSupportedFiles) {
-			slog.Error("Application run failed", "error", err)
-			os.Exit(1)
-		}
-		// If ErrNoSupportedFiles, runApp handles logging and cleanup.
+	slog.Info("Server is listening", "address", cfg.ListenAddress)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("Failed to start HTTP server", "error", err)
+		os.Exit(1)
 	}
 
-	if cfg.MemProfileFile != "" {
-		f, err := os.Create(cfg.MemProfileFile)
-		if err != nil {
-			slog.Error("could not create memory profile", "file", cfg.MemProfileFile, "error", err)
-			os.Exit(1)
-		}
-		defer f.Close()
-		runtime.GC()
-		if err := pprof.WriteHeapProfile(f); err != nil {
-			slog.Error("could not write memory profile", "error", err)
-			os.Exit(1)
-		}
-		slog.Info("Memory profile written", "file", cfg.MemProfileFile)
-	}
-}
-
-func runApp(ctx context.Context, cfg *Config) error {
-	select {
-	case <-ctx.Done():
-		slog.Info("runApp: cancellation detected before starting.")
-		if _, statErr := os.Stat(cfg.OutputFilename); statErr == nil {
-			if removeErr := os.Remove(cfg.OutputFilename); removeErr != nil {
-				slog.Warn("Failed to remove output file during early cancellation", "file", cfg.OutputFilename, "error", removeErr)
-			} else {
-				slog.Info("Removed output file due to early cancellation", "file", cfg.OutputFilename)
-			}
-		}
-		return ctx.Err()
-	default:
-	}
-
-	outFile, err := os.Create(cfg.OutputFilename)
-	if err != nil {
-		return fmt.Errorf("could not create output file %s: %w", cfg.OutputFilename, err)
-	}
-
-	hasContent, conversionErr := convertImagesToPDF(ctx, cfg, outFile)
-
-	if closeErr := outFile.Close(); closeErr != nil {
-		slog.Warn("Failed to close output file", "file", cfg.OutputFilename, "error", closeErr)
-		if conversionErr == nil {
-			conversionErr = fmt.Errorf("failed to close output file %s: %w", cfg.OutputFilename, closeErr)
-		}
-	}
-
-	if conversionErr != nil {
-		if errors.Is(conversionErr, context.Canceled) {
-			slog.Info("PDF conversion canceled.", "inputDir", cfg.InputDirectory, "outputFile", cfg.OutputFilename)
-			if removeErr := os.Remove(cfg.OutputFilename); removeErr != nil {
-				slog.Warn("Failed to remove output file after cancellation", "file", cfg.OutputFilename, "error", removeErr)
-			} else {
-				slog.Debug("Removed output file after cancellation", "file", cfg.OutputFilename)
-			}
-			return context.Canceled
-		}
-		slog.Error("Failed to convert images to PDF", "inputDir", cfg.InputDirectory, "error", conversionErr)
-		if removeErr := os.Remove(cfg.OutputFilename); removeErr != nil {
-			slog.Warn("Failed to remove output file after error", "file", cfg.OutputFilename, "error", removeErr)
-		} else {
-			slog.Debug("Removed output file after error", "file", cfg.OutputFilename)
-		}
-		return conversionErr
-	}
-
-	if !hasContent {
-		slog.Info("No images were successfully added to the PDF. Output file removed.", "inputDir", cfg.InputDirectory, "outputFile", cfg.OutputFilename)
-		if removeErr := os.Remove(cfg.OutputFilename); removeErr != nil {
-			slog.Warn("Failed to remove output file after no content", "file", cfg.OutputFilename, "error", removeErr)
-		}
-		return nil
-	}
-
-	slog.Info("Successfully created PDF", "outputFile", cfg.OutputFilename, "inputDir", cfg.InputDirectory)
-	return nil
-}
-
-func findSupportedImageFiles(inputDir string) ([]string, error) {
-	slog.Debug("Scanning for supported image files", "directory", inputDir)
-	files, err := os.ReadDir(inputDir)
-	if err != nil {
-		return nil, fmt.Errorf("could not read directory %s: %w", inputDir, err)
-	}
-
-	var imageFiles []string
-	supportedExtensions := map[string]bool{
-		".webp": true, ".jpg": true, ".jpeg": true, ".png": true,
-	}
-	for _, file := range files {
-		if !file.IsDir() && supportedExtensions[strings.ToLower(filepath.Ext(file.Name()))] {
-			imageFiles = append(imageFiles, file.Name())
-		}
-	}
-
-	if len(imageFiles) == 0 {
-		slog.Info("No supported image files found", "directory", inputDir)
-		return nil, fmt.Errorf("%w in directory %s", ErrNoSupportedFiles, inputDir)
-	}
-
-	sort.Strings(imageFiles)
-	slog.Debug("Found supported image files", "count", len(imageFiles), "directory", inputDir)
-	return imageFiles, nil
-}
-
-func processImageAndRegister(ctx context.Context, cfg *Config, filename string, idx int) ProcessedImage {
-	slog.Debug("Starting to process image", "filename", filename, "index", idx)
-	select {
-	case <-ctx.Done():
-		slog.Debug("Context cancelled before processing image", "filename", filename)
-		return ProcessedImage{Index: idx, Filename: filename, Error: ctx.Err()}
-	default:
-	}
-
-	fullPath := filepath.Join(cfg.InputDirectory, filename)
-	ext := strings.ToLower(filepath.Ext(filename))
-	processedInfo := ProcessedImage{Index: idx, Filename: filename}
-
-	file, err := os.Open(fullPath)
-	if err != nil {
-		processedInfo.Error = fmt.Errorf("could not open file %s: %w", fullPath, err)
-		return processedInfo
-	}
-	defer file.Close()
-
-	var imgConfig image.Config
-	var formatName string
-	var imageType string
-
-	if ext == ".png" || ext == ".jpg" || ext == ".jpeg" {
-		slog.Debug("Processing as PNG/JPG (direct reader)", "filename", filename)
-		imgConfig, formatName, err = image.DecodeConfig(file)
-		if err != nil {
-			processedInfo.Error = fmt.Errorf("could not decode image config for %s: %w", filename, err)
-			return processedInfo
-		}
-		if _, err = file.Seek(0, io.SeekStart); err != nil {
-			processedInfo.Error = fmt.Errorf("could not seek file %s: %w", filename, err)
-			return processedInfo
-		}
-		imageType = strings.ToUpper(strings.TrimPrefix(ext, "."))
-		if imageType == "JPEG" {
-			imageType = "JPG"
-		}
-		processedInfo.Reader = file
-		processedInfo.Width = float64(imgConfig.Width)
-		processedInfo.Height = float64(imgConfig.Height)
-		processedInfo.ImageTypeForPDF = imageType
-	} else if ext == ".webp" {
-		slog.Debug("Processing as WEBP (decode and re-encode to JPG)", "filename", filename)
-		decodedImg, webpFormatName, err := image.Decode(file)
-		if err != nil {
-			processedInfo.Error = fmt.Errorf("could not decode webp image %s: %w", filename, err)
-			return processedInfo
-		}
-		formatName = webpFormatName
-		switch decodedImg.(type) {
-		case *image.Gray16, *image.NRGBA64, *image.RGBA64:
-			slog.Debug("Converting 16-bit WebP image to 8-bit NRGBA", "filename", filename)
-			decodedImg = imaging.Clone(decodedImg)
-		}
-		buf := bufferPool.Get().(*bytes.Buffer)
-		buf.Reset()
-		if err := imaging.Encode(buf, decodedImg, imaging.JPEG, imaging.JPEGQuality(cfg.JPEGQuality)); err != nil {
-			bufferPool.Put(buf)
-			processedInfo.Error = fmt.Errorf("could not re-encode webp %s to jpg: %w", filename, err)
-			return processedInfo
-		}
-		processedInfo.Reader = buf
-		processedInfo.Width = float64(decodedImg.Bounds().Dx())
-		processedInfo.Height = float64(decodedImg.Bounds().Dy())
-		processedInfo.ImageTypeForPDF = "JPG"
-	} else {
-		processedInfo.Error = fmt.Errorf("unsupported file type by processImageAndRegister: %s", ext)
-		return processedInfo
-	}
-	slog.Debug("Successfully processed image", "filename", filename, "originalFormat", formatName, "pdfType", imageType, "width", processedInfo.Width, "height", processedInfo.Height)
-	return processedInfo
-}
-
-func processImagesConcurrently(ctx context.Context, cfg *Config, imageFiles []string) []ProcessedImage {
-	slog.Debug("Starting concurrent image processing", "numFiles", len(imageFiles), "numWorkers", cfg.NumWorkers)
-	if len(imageFiles) == 0 {
-		return []ProcessedImage{}
-	}
-
-	processedImageChan := make(chan ProcessedImage)
-	semaphoreChan := make(chan struct{}, cfg.NumWorkers)
-	var wg sync.WaitGroup
-	results := make([]ProcessedImage, len(imageFiles))
-
-	for i, filename := range imageFiles {
-		select {
-		case <-ctx.Done():
-			slog.Info("Cancellation detected before starting all goroutines", "lastProcessedIndex", i-1, "filename", filename)
-			for j := i; j < len(imageFiles); j++ {
-				if results[j].Filename == "" {
-					results[j] = ProcessedImage{Index: j, Filename: imageFiles[j], Error: ctx.Err()}
-				}
-			}
-			goto endGoroutineLoop
-		default:
-		}
-
-		wg.Add(1)
-		go func(idx int, fname string) {
-			defer wg.Done()
-			slog.Debug("Goroutine started for image", "filename", fname, "index", idx)
-			select {
-			case semaphoreChan <- struct{}{}:
-				defer func() { <-semaphoreChan }()
-			case <-ctx.Done():
-				slog.Debug("Cancellation detected before acquiring semaphore", "filename", fname)
-				processedImageChan <- ProcessedImage{Index: idx, Filename: fname, Error: ctx.Err()}
-				return
-			}
-
-			processedResult := processImageAndRegister(ctx, cfg, fname, idx)
-			select {
-			case processedImageChan <- processedResult:
-			case <-ctx.Done():
-				slog.Debug("Cancellation detected while trying to send result", "filename", fname)
-				if processedResult.Error == nil {
-					processedResult.Error = ctx.Err()
-				}
-				if closer, ok := processedResult.Reader.(io.Closer); ok {
-					closer.Close()
-				} else if buf, ok := processedResult.Reader.(*bytes.Buffer); ok {
-					bufferPool.Put(buf)
-				}
-				processedImageChan <- processedResult // Attempt to send anyway for accounting
-			}
-		}(i, filename)
-	}
-
-endGoroutineLoop:
-	go func() {
-		wg.Wait()
-		close(processedImageChan)
-		close(semaphoreChan)
-		slog.Debug("All image processing goroutines completed.")
-	}()
-
-	for i := 0; i < len(imageFiles); i++ {
-		select {
-		case res, ok := <-processedImageChan:
-			if ok {
-				results[res.Index] = res
-			} else { // Channel closed
-				slog.Debug("Processed image channel closed.")
-				// Fill remaining with cancellation error if context is done
-				if ctx.Err() != nil {
-					for k := 0; k < len(imageFiles); k++ {
-						if results[k].Filename == "" {
-							results[k] = ProcessedImage{Index: k, Filename: imageFiles[k], Error: ctx.Err()}
-						}
-					}
-				}
-				goto endCollectionLoop
-			}
-		case <-ctx.Done():
-			slog.Info("Cancellation detected while collecting results.")
-			for j := 0; j < len(imageFiles); j++ {
-				if results[j].Filename == "" {
-					results[j] = ProcessedImage{Index: j, Filename: imageFiles[j], Error: ctx.Err()}
-				}
-			}
-			goto endCollectionLoop
-		}
-	}
-endCollectionLoop:
-	if ctx.Err() != nil { // Drain channel if cancelled to let goroutines finish sending
-		for range processedImageChan {
-		}
-	}
-	slog.Debug("Finished collecting image processing results.")
-	return results
-}
-
-func generatePDFFromProcessedImages(ctx context.Context, writer io.Writer, processedImages []ProcessedImage, pdf *gofpdf.Fpdf) (hasContent bool, err error) {
-	slog.Debug("Starting PDF generation from processed images", "numImages", len(processedImages))
-	hasContent = false
-	for i, res := range processedImages {
-		select {
-		case <-ctx.Done():
-			slog.Info("Cancellation detected before adding image to PDF", "filename", res.Filename)
-			if res.Error == nil {
-				if closer, ok := res.Reader.(io.Closer); ok {
-					closer.Close()
-				} else if buf, ok := res.Reader.(*bytes.Buffer); ok {
-					bufferPool.Put(buf)
-				}
-			}
-			return hasContent, ctx.Err()
-		default:
-		}
-
-		if res.Error != nil {
-			if errors.Is(res.Error, context.Canceled) {
-				slog.Debug("Skipping image due to earlier cancellation", "filename", res.Filename)
-			} else {
-				slog.Warn("Skipping image due to error during its processing", "filename", res.Filename, "error", res.Error)
-			}
-			if closer, ok := res.Reader.(io.Closer); ok {
-				closer.Close()
-			} else if buf, ok := res.Reader.(*bytes.Buffer); ok {
-				bufferPool.Put(buf)
-			}
-			continue
-		}
-		if res.Reader == nil {
-			slog.Warn("Reader for image is nil, skipping", "filename", res.Filename)
-			continue
-		}
-
-		slog.Debug("Adding image to PDF", "filename", res.Filename, "width", res.Width, "height", res.Height, "type", res.ImageTypeForPDF)
-		readerToClean := res.Reader
-		pdf.AddPageFormat("P", gofpdf.SizeType{Wd: res.Width, Ht: res.Height})
-		if pdf.Err() {
-			slog.Warn("Could not add page to PDF for image", "filename", res.Filename, "error", pdf.Error())
-			pdf.ClearError()
-			if closer, ok := readerToClean.(io.Closer); ok {
-				closer.Close()
-			} else if buf, ok := readerToClean.(*bytes.Buffer); ok {
-				bufferPool.Put(buf)
-			}
-			continue
-		}
-
-		imageName := fmt.Sprintf("image%d", i)
-		pdf.RegisterImageOptionsReader(imageName, gofpdf.ImageOptions{ImageType: res.ImageTypeForPDF, ReadDpi: false}, res.Reader)
-		if fCloser, ok := readerToClean.(*os.File); ok {
-			fCloser.Close()
-		} else if bReader, ok := readerToClean.(*bytes.Buffer); ok {
-			bufferPool.Put(bReader)
-		}
-
-		if pdf.Err() {
-			slog.Warn("Could not register image in PDF", "filename", res.Filename, "error", pdf.Error())
-			pdf.ClearError()
-			continue
-		}
-
-		pdf.ImageOptions(imageName, 0, 0, res.Width, res.Height, false, gofpdf.ImageOptions{ImageType: res.ImageTypeForPDF}, 0, "")
-		if pdf.Err() {
-			slog.Warn("Could not place image on PDF page", "filename", res.Filename, "error", pdf.Error())
-			pdf.ClearError()
-			continue
-		}
-		hasContent = true
-		slog.Debug("Successfully added image to PDF", "filename", res.Filename)
-	}
-
-	if pdf.Err() {
-		return hasContent, fmt.Errorf("error generating PDF structure: %w", pdf.Error())
-	}
-
-	select {
-	case <-ctx.Done():
-		slog.Info("Cancellation detected before writing PDF output.")
-		return hasContent, ctx.Err()
-	default:
-	}
-
-	if hasContent {
-		slog.Debug("Writing PDF to output stream...")
-		if err := pdf.Output(writer); err != nil {
-			return true, fmt.Errorf("could not write PDF to writer: %w", err)
-		}
-		slog.Debug("Successfully wrote PDF to output stream.")
-	} else {
-		if ctx.Err() != nil {
-			return false, ctx.Err()
-		}
-		if len(processedImages) > 0 {
-			slog.Info("No content was added to the PDF (all images skipped or failed).")
-		} else {
-			slog.Info("No images processed and no content to add to PDF.")
-		}
-	}
-	return hasContent, nil
-}
-
-func convertImagesToPDF(ctx context.Context, cfg *Config, writer io.Writer) (hasContent bool, err error) {
-	slog.Debug("Starting PDF conversion process", "inputDir", cfg.InputDirectory)
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
-	}
-
-	imageFiles, err := findSupportedImageFiles(cfg.InputDirectory)
-	if err != nil {
-		return false, err
-	}
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
-	}
-	if len(imageFiles) == 0 {
-		return false, ErrNoSupportedFiles // Should be caught by findSupportedImageFiles, but defensive.
-	}
-	slog.Info("Found image files to convert", "count", len(imageFiles), "inputDir", cfg.InputDirectory)
-
-	pdf := gofpdf.New("P", "pt", "A4", "")
-	processedImageInfos := processImagesConcurrently(ctx, cfg, imageFiles)
-
-	select {
-	case <-ctx.Done():
-		slog.Info("Cancellation detected before PDF generation phase.")
-		for _, info := range processedImageInfos {
-			if info.Error == nil || !errors.Is(info.Error, context.Canceled) {
-				if closer, ok := info.Reader.(io.Closer); ok {
-					closer.Close()
-				} else if buf, ok := info.Reader.(*bytes.Buffer); ok {
-					bufferPool.Put(buf)
-				}
-			}
-		}
-		return false, ctx.Err()
-	default:
-	}
-	return generatePDFFromProcessedImages(ctx, writer, processedImageInfos, pdf)
+	<-idleConnsClosed // Wait for graceful shutdown to complete
+	slog.Info("Application shut down successfully.")
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,197 @@
+openapi: 3.0.0
+info:
+  title: Image to PDF Conversion API
+  version: "1.0.0"
+  description: |-
+    An API for converting a collection of images (from uploads or URLs) into a single PDF document.
+    The API supports various image formats and provides configuration options for the conversion process.
+servers:
+  - url: http://localhost:8080 # Default local server
+    description: Local development server
+  # Add other environments like staging or production here if applicable
+  # - url: https://api.example.com/v1
+  #   description: Production server
+
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: A human-readable error message.
+          example: "Invalid 'config' JSON"
+        details:
+          type: string # Can be an object or array too for more complex errors
+          description: Optional further details about the error.
+          example: "unexpected end of JSON input"
+      required:
+        - error
+
+    ConversionConfig:
+      type: object
+      properties:
+        output_filename:
+          type: string
+          description: Suggested filename for the output PDF. If not provided, a default will be used (e.g., 'converted.pdf'). The Content-Disposition header will use this name.
+          example: "my_manga_chapter.pdf"
+        jpeg_quality:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 100
+          default: 90
+          description: JPEG quality setting for WEBP to JPG conversion and for JPG re-encoding if necessary (1-100).
+          example: 85
+        num_workers:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Number of concurrent workers for image processing. Defaults to the number of CPU cores.
+          example: 4
+      # Add other future configuration parameters here
+
+  requestBodies:
+    ConversionRequest:
+      description: Request body for image to PDF conversion.
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              images:
+                type: array
+                items:
+                  type: string
+                  format: binary
+                description: Image files to be included in the PDF. Max total payload size for multipart/form-data is server-dependent (e.g., 32MB).
+              image_urls:
+                type: string # Represented as a JSON string array in the form data
+                format: json # This is a hint; actual validation is of the string content
+                description: A JSON-encoded array of strings, where each string is a URL to an image. E.g., '["http://example.com/image1.jpg", "http://example.com/image2.png"]'.
+                example: '["https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885_1280.jpg"]'
+              config:
+                type: string # Represented as a JSON string object in the form data
+                format: json # Hint for JSON structure
+                description: A JSON-encoded object containing configuration options. See '#/components/schemas/ConversionConfig'.
+                example: '{"output_filename": "custom_name.pdf", "jpeg_quality": 75}'
+          encoding: # Specify encoding for parts if necessary, though defaults are usually fine
+            images:
+              contentType: image/jpeg, image/png, image/webp # Common types, server will attempt to process based on actual data too
+            # No special encoding needed for image_urls or config as they are strings
+
+paths:
+  /convert:
+    post:
+      summary: Convert images to PDF
+      description: |-
+        Uploads image files and/or provides image URLs to convert them into a single PDF document.
+        The order of images in the PDF is determined by:
+        1. The order of 'images' file parts in the multipart request.
+        2. Followed by the order of URLs in the 'image_urls' JSON array.
+      operationId: convertImagesToPdf
+      requestBody:
+        $ref: '#/components/requestBodies/ConversionRequest'
+      responses:
+        '200':
+          description: PDF generated successfully. The PDF is returned as a binary stream.
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Disposition:
+              description: Suggests a filename for the downloaded PDF (e.g., 'attachment; filename="converted.pdf"').
+              schema:
+                type: string
+                example: 'attachment; filename="my_document.pdf"'
+            Content-Length:
+              description: The size of the PDF body in bytes.
+              schema:
+                type: integer
+        '400':
+          description: Bad Request. Invalid input, such as malformed JSON, missing required fields, or issues with request structure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidJson:
+                  summary: Invalid JSON in config
+                  value:
+                    error: "Invalid 'config' JSON"
+                    details: "unexpected character '}' looking for beginning of object key string"
+                noImages:
+                  summary: No images provided
+                  value:
+                    error: "No images provided"
+                    details: "Please upload files or provide image URLs."
+        '422':
+          description: Unprocessable Entity. Images could not be processed, e.g., unsupported image format, corrupted image, URL inaccessible or points to non-image content.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                imageProcessingError:
+                  summary: Error processing an image
+                  value:
+                    error: "No images could be processed into the PDF"
+                    details: "no supported images were successfully processed"
+                unsupportedContentType:
+                  summary: URL points to non-image
+                  value:
+                    error: "Unsupported image content type from URL"
+                    details: "unsupported content type from URL: text/html; charset=utf-8 from http://example.com/not_an_image"
+        '500':
+          description: Internal Server Error. An unexpected error occurred on the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: Generic server error
+                  value:
+                    error: "Failed to convert images to PDF"
+                    details: "An internal error occurred."
+  /health:
+    get:
+      summary: Health Check
+      description: Provides a simple health check for the service.
+      operationId: healthCheck
+      responses:
+        '200':
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+        '503':
+          description: Service Unavailable. The service is not healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: unavailable
+                  # Optionally, include more details about the unhealthy state
+                  # details:
+                  #   type: string
+                  #   example: "Database connection lost"
+# You can add securitySchemes and security sections here if authentication is added later.
+# securitySchemes:
+#   ApiKeyAuth:
+#     type: apiKey
+#     in: header
+#     name: X-API-KEY
+# security:
+#   - ApiKeyAuth: []


### PR DESCRIPTION
- Implemented a /convert POST endpoint to accept image uploads and URLs.
- Implemented a /health GET endpoint.
- Refactored core conversion logic into an internal 'converter' package.
- Added OpenAPI (openapi.yaml) for API documentation.
- Removed CLI-specific functionality from main.go.
- Updated README.md to reflect API usage.
- Added unit tests for the converter package and integration tests for API handlers.