### PR TITLE
feat: Add GoReleaser and GitHub Actions for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# .github/workflows/release.yml
+name: Release Go Project
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v0.1.2, etc.
+
+permissions:
+  contents: write # Needed to create releases and upload artifacts
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetches all history so GoReleaser can generate a changelog
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21' # Specify your Go version, align with go.mod if possible
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest # Or pin to a specific GoReleaser version e.g., v1.20.0
+          args: --clean # Ensure a clean build environment
+
+      - name: Run GoReleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goreleaser release --clean
+        # The GITHUB_TOKEN is automatically available to the workflow
+        # and GoReleaser uses it to publish releases to GitHub.
+        # The --clean flag ensures that any artifacts from previous builds are removed.
+
+      # Example of how to upload artifacts to the release if not using GoReleaser's built-in upload
+      # - name: Upload Release Assets
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.goreleaser.outputs.upload_url }} # This requires GoReleaser action to output the upload URL
+      #     asset_path: ./dist/* # Path to your built artifacts
+      #     asset_name: ${{ github.event.repository.name }}-${{ github.ref_name }}.zip # Example asset name
+      #     asset_content_type: application/zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,121 @@
+# .goreleaser.yml
+# For more information see: https://goreleaser.com/customization/
+project_name: manga_to_pdf
+
+# Environment variables to be used in the build process
+env:
+  - GO111MODULE=on
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    # - go generate ./...
+
+builds:
+  - # Build configuration for the main application
+    id: "manga_to_pdf"
+    # Path to the main Go file or package.
+    main: ./main.go
+    # Binary name (without extension).
+    binary: manga_to_pdf_server
+    # GOOS and GOARCH to build for.
+    # For a complete list of supported GOOS and GOARCH values,
+    # run `go tool dist list`.
+    goos:
+      - linux
+      - windows
+      - darwin # macOS
+    goarch:
+      - amd64
+      - arm64
+    # GOARM to build for (if GOARCH is arm).
+    # goarm:
+    #   - "6"
+    #   - "7"
+    # Custom build flags.
+    # ldflags:
+    #   - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+    flags:
+      - -trimpath
+    # Mod timestamp for reproducible builds
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+archives:
+  - # Archive configuration
+    id: "manga_to_pdf_archives"
+    # Name template for the archive.
+    # Default is `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}`
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Format of the archive.
+    # Supported formats are `tar.gz`, `zip`, `binary` (no archive).
+    # Default is `tar.gz`.
+    format: zip # Using zip for better Windows compatibility
+    # Files to include in the archive.
+    files:
+      - README.md
+      # - LICENSE # Add a LICENSE file if you have one
+      - openapi.yaml
+      # - config_*.json # If you have default config files to distribute
+
+checksum:
+  # Algorithm to use for checksums.
+  # Supported algorithms are `sha256`, `sha512`, `sha1`, `md5`, `crc32`.
+  # Default is `sha256`.
+  algorithm: sha256
+  # Name template for the checksums file.
+  # Default is `{{ .ProjectName }}_{{ .Version }}_checksums.txt`.
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+
+snapshot:
+  # Name template for snapshot builds.
+  # Default is `{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}`.
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  # Sort order for changes.
+  # Supported values are `asc`, `desc`.
+  # Default is `asc`.
+  sort: asc
+  # Filters for commit messages.
+  filters:
+    # Exclude commit messages that match the given regular expressions.
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge branch"
+      - "Merge pull request"
+
+# Release configuration for GitHub, GitLab, Gitea.
+# For more information see: https://goreleaser.com/customization/publish/
+release:
+  # If set to true, GoReleaser will not publish the release.
+  # Useful for testing the release process.
+  # Default is false.
+  # draft: true
+
+  # If set to true, will mark the release as a prerelease.
+  # Default is true if the tag is a prerelease (e.g. v1.0.0-rc1).
+  # prerelease: auto
+
+  # You can change the name of the GitHub release.
+  # Default is `{{.Tag}}`
+  name_template: "{{.ProjectName}} {{.Tag}}"
+
+  # Header for the release notes.
+  # header: |
+  #   Release notes for {{.ProjectName}} {{.Tag}}
+
+  # Footer for the release notes.
+  # footer: |
+  #   ---
+  #   Released by GoReleaser
+
+  # If set to true, will append the changelog to the release notes.
+  # Default is true.
+  # disable_changelog_notes: false
+
+# Modelines - code editor hints
+# vim: Codelang=yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,4 +75,22 @@ This document provides guidelines for AI agents working on this project. The pri
 *   **End-to-End (E2E) Tests (Future)**: As the API matures, E2E tests simulating client interactions would be beneficial.
 *   **Performance Tests**: Use benchmarks to ensure performance targets are met.
 
+### 8. Release Process
+
+*   **Tooling**: This project uses [GoReleaser](https://goreleaser.com/) for building and packaging releases, and [GitHub Actions](https://github.com/features/actions) for automating the release workflow.
+*   **Trigger**: Releases are triggered by pushing a Git tag to the repository that follows semantic versioning, specifically matching the pattern `v*.*.*` (e.g., `v1.0.0`, `v0.2.1`).
+*   **Workflow**: The GitHub Actions workflow is defined in `.github/workflows/release.yml`. When a valid tag is pushed:
+    *   It checks out the code.
+    *   Sets up the Go environment.
+    *   Installs GoReleaser.
+    *   Runs `goreleaser release --clean` which:
+        *   Builds the `manga_to_pdf_server` binary for multiple platforms (Linux, Windows, macOS - amd64, arm64).
+        *   Archives the binary along with `README.md` and `openapi.yaml`.
+        *   Generates a checksum file for the archives.
+        *   Creates a new GitHub Release associated with the tag.
+        *   Uploads the archives and checksum file as assets to the GitHub Release.
+        *   Generates release notes from commit messages (commits like `docs:`, `test:`, `chore:`, and merge commits are excluded).
+*   **Tagging Convention**: Tags MUST follow Semantic Versioning 2.0.0, prefixed with a `v`. For example: `v1.0.0`, `v0.1.0`, `v0.1.1-alpha`.
+*   **Local Testing**: The release process can be tested locally without creating an actual GitHub release by running `goreleaser release --snapshot --clean` from the project root. This will build artifacts into the `dist/` directory.
+
 By adhering to these guidelines, we aim to create a high-quality, maintainable, and efficient API.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,44 @@ go tool pprof http://localhost:8080/debug/pprof/heap # Memory profile
 
 For AI development guidelines and project principles, refer to `AGENTS.md`.
 
+## Creating a Release
+
+This project uses [GoReleaser](https://goreleaser.com/) and GitHub Actions to automate the release process.
+
+To create a new release:
+
+1.  **Ensure your `main` branch is up-to-date and all changes for the release are merged.**
+2.  **Tag the commit you want to release.** Tags should follow semantic versioning (e.g., `v1.0.0`, `v0.2.1`).
+    ```bash
+    git tag -a vX.Y.Z -m "Release vX.Y.Z"
+    ```
+    Replace `vX.Y.Z` with the desired version number.
+3.  **Push the tag to GitHub:**
+    ```bash
+    git push origin vX.Y.Z
+    ```
+    Pushing a tag in the format `v*.*.*` will trigger the `Release Go Project` GitHub Actions workflow defined in `.github/workflows/release.yml`. This workflow will:
+    *   Build the `manga_to_pdf_server` binary for Linux, Windows, and macOS (amd64 and arm64 architectures).
+    *   Create archives (ZIP files) containing the binary, `README.md`, and `openapi.yaml`.
+    *   Generate checksums for the archives.
+    *   Create a new GitHub Release with the tag.
+    *   Upload the archives and checksums as release assets.
+    *   Generate release notes based on commit messages since the last tag (excluding docs, test, chore commits, and merge commits).
+
+### Local Release Testing (Dry Run)
+
+You can test the GoReleaser process locally without creating a GitHub release. This is useful for verifying the build and packaging steps.
+
+1.  **Install GoReleaser** (if you haven't already): [GoReleaser Installation](https://goreleaser.com/install/)
+2.  **Run the local release command from the project root:**
+    ```bash
+    goreleaser release --snapshot --clean
+    ```
+    *   `--snapshot`: Builds and archives but doesn't publish. Output will be in the `dist` folder.
+    *   `--clean`: Ensures a clean build by removing the `dist` folder before starting.
+
+This will simulate the release process and place the generated artifacts in a `dist` directory.
+
 ## Future Enhancements
 
 *   Asynchronous processing for long conversions (e.g., using job queues and status endpoints).


### PR DESCRIPTION
This commit introduces GoReleaser and a GitHub Actions workflow to automate the creation of releases.

- Adds `.goreleaser.yml` to configure the build, archival, and release process.
- Adds `.github/workflows/release.yml` to trigger releases on version tags (e.g., v1.0.0).
- Updates `README.md` with instructions on how to create a release and test locally.
- Updates `AGENTS.md` with details about the new release process and conventions.